### PR TITLE
Only if IC expanded - checks all enabled consumables

### DIFF
--- a/Core/Auras.lua
+++ b/Core/Auras.lua
@@ -4,18 +4,22 @@
 SIPPYCUP.Auras = {};
 SIPPYCUP.Auras.InLoadingScreen = false;
 
----CheckedEnabledAurasForConsumables iterates over all the enabled Sippy Cup consumables to see if they are active and passes that to Popup handling.
+---CheckCurrentConsumablesForDesiredStacks iterates over all the ACTIVE enabled Sippy Cup consumables to see if they are at the correct stack size.
+---@param checkAll boolean? If set and true, the check will also go over all the non-active enabled consumables.
 ---@return nil
-function SIPPYCUP.Auras.CheckedEnabledAurasForConsumables()
+function SIPPYCUP.Auras.CheckConsumableStackSizes(checkAll)
 	local GetPlayerAuraBySpellID = C_UnitAuras.GetPlayerAuraBySpellID;
 
 	for _, profileConsumableData in pairs(SIPPYCUP.db.profile) do
 		if profileConsumableData.enable and profileConsumableData.aura then
 			local auraInfo = GetPlayerAuraBySpellID(profileConsumableData.aura);
 
-			if auraInfo then
-				SIPPYCUP.Popups.QueuePopupAction(false, profileConsumableData.aura, auraInfo, auraInfo.auraInstanceID);
+			-- If checkAll is not true, and auraInfo is not found, then we stop.
+			if not checkAll and not auraInfo then
+				return;
 			end
+
+			SIPPYCUP.Popups.QueuePopupAction(false, profileConsumableData.aura, auraInfo, auraInfo and auraInfo.auraInstanceID or nil);
 		end
 	end
 end

--- a/Core/Database.lua
+++ b/Core/Database.lua
@@ -95,7 +95,7 @@ local function RefreshConfig()
 	AceConfigRegistry:RegisterOptionsTable(title .. "_Size", SIPPYCUP_CONFIG.GenerateCategory("SIZE"));
 
 	-- Check if any enabled consumables are active, run the required popup logic.
-	SIPPYCUP.Auras.CheckedEnabledAurasForConsumables();
+	SIPPYCUP.Auras.CheckConsumableStackSizes(SIPPYCUP.db.global.MSPStatusCheck);
 end
 
 ---Setup initializes the database, registers callbacks, and configures options tables for the addon.

--- a/SippyCup.lua
+++ b/SippyCup.lua
@@ -37,8 +37,14 @@ function SIPPYCUP_Addon:OnEnable()
 	SIPPYCUP.Minimap:SetupMinimapButtons();
 
 	self:StartAuraCheck();
-	-- Check if any enabled consumables are active, run the required popup logic.
-	SIPPYCUP.Auras.CheckedEnabledAurasForConsumables();
+	-- Check all enabled consumables to see if we have to track any (or enable if setting is set).
+	SIPPYCUP.Auras.CheckConsumableStackSizes(SIPPYCUP.db.global.MSPStatusCheck);
+
+	if msp and msp.my then
+		table.insert(msp.callback["updated"], function()
+			SIPPYCUP.Auras.CheckConsumableStackSizes(SIPPYCUP.db.global.MSPStatusCheck)
+		end)
+	end
 
 	if SIPPYCUP.db.global.WelcomeMessage then
 		SIPPYCUP_OUTPUT.Write(L.WELCOMEMSG_VERSION:format(SIPPYCUP.AddonMetadata.version));

--- a/UI/ConfigPanel.lua
+++ b/UI/ConfigPanel.lua
@@ -266,6 +266,9 @@ function SIPPYCUP_CONFIG.GenerateGeneral()
 				end,
 				set = function(_, val)
 					SIPPYCUP.db.global.MSPStatusCheck = val;
+					if val then
+						SIPPYCUP.Auras.CheckConsumableStackSizes(val);
+					end
 				end,
 				width = THIRD_WIDTH,
 				order = autoOrder(),


### PR DESCRIPTION
This basically adds new functionality, some of it is repeats of one another.

When the user toggles "Only when In Character" on and is IC (this should only happen once):
- It will check ALL enabled (inactive and active) consumables and fire a popup if they're disabled or not the right stack size.

If a user has the "Only when In Character" option checked, the following happens:
- On login, if the user is IC it will check ALL enabled (inactive and active) consumables and fire a popup if they're disabled or not the right stack size.
- When going IC on a RP profile addon (TRP, MRP, XRP, etc.), it will check ALL enabled (inactive and active) consumables and fire a popup if they're disabled or not the right stack size.
- Reminder popups will NOT show when the user is OOC (obviously), but this means not at all.

It he user is not running any addons that support IC/OOC, then it will work as previously:
- On login, it will ONLY check active enabled consumables and fire a popup if they're not the right stack size.
- Popups will always show, regardless of any status.