### PR TITLE
Initial addon states

### DIFF
--- a/Core/Consumables.lua
+++ b/Core/Consumables.lua
@@ -98,8 +98,6 @@ for _, consumable in ipairs(SIPPYCUP.Consumables.Data) do
 	SIPPYCUP.Consumables.ByItemID[consumable.itemID] = consumable;
 end
 
-SIPPYCUP.deferSetup = false;
-
 for _, consumable in ipairs(SIPPYCUP.Consumables.Data) do
 	local item = Item:CreateFromItemID(consumable.itemID);
 	item:ContinueOnItemLoad(function()
@@ -123,6 +121,10 @@ for _, consumable in ipairs(SIPPYCUP.Consumables.Data) do
 			table.sort(SIPPYCUP.Consumables.Data, function(a, b)
 				return SIPPYCUP_TEXT.Normalize(a.name:lower()) < SIPPYCUP_TEXT.Normalize(b.name:lower());
 			end);
+
+			SIPPYCUP.state.consumablesLoaded = true;
+			-- Attempt Addon startup.
+			SIPPYCUP_Addon:Startup();
 
 			--[[
 			if SIPPYCUP.db then

--- a/Core/Consumables.lua
+++ b/Core/Consumables.lua
@@ -125,18 +125,6 @@ for _, consumable in ipairs(SIPPYCUP.Consumables.Data) do
 			SIPPYCUP.state.consumablesLoaded = true;
 			-- Attempt Addon startup.
 			SIPPYCUP_Addon:Startup();
-
-			--[[
-			if SIPPYCUP.db then
-				-- RUN DEFERRED SETUP
-				-- SIPPYCUP.Database.RefreshUI();
-				print("DB was ready");
-			else
-				-- Defer SetupConfig until DB is ready
-				SIPPYCUP.deferSetup = true;
-				print("DB was not ready");
-			end
-			]]
 		end
 	end);
 end

--- a/Core/Core.xml
+++ b/Core/Core.xml
@@ -5,8 +5,12 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
 ..\FrameXML\UI.xsd">
 	<Include file="Utils.lua"/>
+
 	<Include file="Auras.lua"/>
 	<Include file="Items.lua"/>
+
+	<Include file="..\UI\Config.xml"/>
+
 	<Include file="Consumables.lua"/>
 	<Include file="Database.lua"/>
 </Ui>

--- a/Core/Database.lua
+++ b/Core/Database.lua
@@ -396,6 +396,10 @@ function SIPPYCUP.Database.Setup()
 	-- Set resolved working profile for runtime use
 	SIPPYCUP.profile = workingProfile;
 
+	SIPPYCUP.state.databaseLoaded = true;
+	-- Attempt Addon startup.
+	SIPPYCUP_Addon:Startup();
+
 	-- Optional deferred config setup
 	--[[
 	if SIPPYCUP.deferSetup then

--- a/Core/Database.lua
+++ b/Core/Database.lua
@@ -399,14 +399,6 @@ function SIPPYCUP.Database.Setup()
 	SIPPYCUP.state.databaseLoaded = true;
 	-- Attempt Addon startup.
 	SIPPYCUP_Addon:Startup();
-
-	-- Optional deferred config setup
-	--[[
-	if SIPPYCUP.deferSetup then
-		print("DB was not ready so doing it now.");
-		-- SIPPYCUP.Database.RefreshUI();
-	end
-	]]
 end
 
 ---GetAllProfiles returns a table of profile names keyed by name.

--- a/Init.lua
+++ b/Init.lua
@@ -4,6 +4,12 @@
 ---@class SIPPYCUP
 local _, SIPPYCUP = ...;
 
+SIPPYCUP.state = {
+	addonLoaded = false,
+	consumablesLoaded = false,
+	databaseLoaded = false,
+};
+
 -- Create a single event dispatcher frame for all addon events
 local events = CreateFrame("Frame", "SIPPYCUP_EventFrame");
 _G.SIPPYCUP_Addon = events;

--- a/SippyCup.lua
+++ b/SippyCup.lua
@@ -46,20 +46,20 @@ function SIPPYCUP_Addon:PLAYER_LOGIN()
 	SIPPYCUP.Events:UnregisterEvent("PLAYER_LOGIN");
 end
 
-local configFrame = nil;
-
 ---OpenSettings toggles the main configuration frame and switches to a specified tab.
 ---@param view number? Optional tab number to open, defaults to 1.
-function SIPPYCUP_Addon:OpenSettings(view)
-	if not configFrame then
-		configFrame = CreateFrame("Frame", "SIPPYCUP_ConfigMenuFrame", UIParent, "SIPPYCUP_ConfigMenuTemplate");
+function SIPPYCUP_Addon:OpenSettings(view)	
+	if not SIPPYCUP.configFrame then
+		SIPPYCUP.Config.TryCreateConfigFrame();
 	end
 
-	configFrame:SetShown(not configFrame:IsShown());
-	configFrame:Raise();
+	if SIPPYCUP.configFrame then
+		SIPPYCUP.configFrame:SetShown(not SIPPYCUP.configFrame:IsShown());
+		SIPPYCUP.configFrame:Raise();
 
-	local tabToOpen = view or 1;
-	SIPPYCUP_ConfigMenuFrame:SetTab(tabToOpen);
+		local tabToOpen = view or 1;
+		SIPPYCUP_ConfigMenuFrame:SetTab(tabToOpen);
+	end
 end
 
 ---OnEnable runs during PLAYER_LOGIN, register game events, hook functions, create frames, etc.

--- a/SippyCup.lua
+++ b/SippyCup.lua
@@ -195,6 +195,12 @@ function SIPPYCUP_Addon:Startup()
 
 	if not SIPPYCUP.InLoadingScreen then
 		SIPPYCUP_Addon:StartContinuousCheck()
+
+		-- isFullUpdate can pass through loading screens (but our code can't), so handle it now.
+		if SIPPYCUP.hasSeenFullUpdate then
+			SIPPYCUP.hasSeenFullUpdate = false;
+			SIPPYCUP.Auras.CheckAllActiveConsumables();
+		end
 	end
 end
 
@@ -208,7 +214,7 @@ local function PlayerLoading(isLoading)
 		SIPPYCUP.InLoadingScreen = false;
 		SIPPYCUP_Addon:StartContinuousCheck()
 
-		-- isFullUpdate can pass through loading screens, so handle it now.
+		-- isFullUpdate can pass through loading screens (but our code can't), so handle it now.
 		if SIPPYCUP.hasSeenFullUpdate then
 			SIPPYCUP.hasSeenFullUpdate = false;
 			SIPPYCUP.Auras.CheckAllActiveConsumables();

--- a/SippyCup.lua
+++ b/SippyCup.lua
@@ -128,9 +128,9 @@ end
 local CONTINUOUS_CHECK_INTERVAL = 180.0;
 ---StartContinuousCheck begins repeating timers (3 minutes interval) for pre-expiration aura checks and no-aura item usage, if not in combat.
 function SIPPYCUP_Addon:StartContinuousCheck()
-	-- don’t run if we’re in combat or the user has disabled pre‑expiration checks
-	if InCombatLockdown() then
-		return
+	-- don’t run if we’re in combat or addon is not loaded fully.
+	if InCombatLockdown() or not SIPPYCUP.state.addonLoaded then
+		return;
 	end
 
 	-- Both below timers don't need an immediate run as startup + new enables run these partially.
@@ -175,7 +175,30 @@ function SIPPYCUP_Addon:PLAYER_REGEN_ENABLED()
 	self:StartContinuousCheck();
 end
 
-local startupCheck = true;
+---Startup initializes the addon once both the database and consumables are loaded.
+---Sets addonLoaded, creates the config frame, initializes MSP with fallback, and starts periodic checks unless.
+---@return nil
+function SIPPYCUP_Addon:Startup()
+	if not SIPPYCUP.state.databaseLoaded or not SIPPYCUP.state.consumablesLoaded then
+		return;
+	end
+	SIPPYCUP.state.addonLoaded = true;
+	SIPPYCUP_OUTPUT.Debug("Consumables & Database loaded.");
+
+	SIPPYCUP.Config.TryCreateConfigFrame();
+
+	-- Prepare our MSP checks.
+	if not SIPPYCUP.MSP.EnableIfAvailable() then
+		-- If not, we'll do a simple stacksize refresh.
+		SIPPYCUP.Consumables.RefreshStackSizes(false);
+	end
+
+	if not SIPPYCUP.InLoadingScreen then
+		SIPPYCUP_Addon:StartAuraCheck();
+		SIPPYCUP_Addon:StartContinuousCheck()
+	end
+end
+
 ---PlayerLoading handles loading screen state changes, stopping checks when loading and starting them when done.
 ---@param isLoading boolean True if loading screen is active, false if loading finished.
 local function PlayerLoading(isLoading)
@@ -190,14 +213,6 @@ local function PlayerLoading(isLoading)
 		if SIPPYCUP.hasSeenFullUpdate then
 			SIPPYCUP.hasSeenFullUpdate = false;
 			SIPPYCUP.Auras.CheckAllActiveConsumables();
-		end
-
-		if startupCheck then
-			if not SIPPYCUP.MSP.EnableIfAvailable() then
-				-- If not, we'll do a simple stacksize refresh.
-				SIPPYCUP.Consumables.RefreshStackSizes(false);
-			end
-			startupCheck = false;
 		end
 	end
 end

--- a/SippyCup.lua
+++ b/SippyCup.lua
@@ -194,7 +194,6 @@ function SIPPYCUP_Addon:Startup()
 	end
 
 	if not SIPPYCUP.InLoadingScreen then
-		SIPPYCUP_Addon:StartAuraCheck();
 		SIPPYCUP_Addon:StartContinuousCheck()
 	end
 end

--- a/SippyCup.lua
+++ b/SippyCup.lua
@@ -48,7 +48,7 @@ end
 
 ---OpenSettings toggles the main configuration frame and switches to a specified tab.
 ---@param view number? Optional tab number to open, defaults to 1.
-function SIPPYCUP_Addon:OpenSettings(view)	
+function SIPPYCUP_Addon:OpenSettings(view)
 	if not SIPPYCUP.configFrame then
 		SIPPYCUP.Config.TryCreateConfigFrame();
 	end

--- a/SippyCup.xml
+++ b/SippyCup.xml
@@ -8,7 +8,6 @@
 	<Include file="Locales\Locales.xml"/>
 	<Include file="Locales\Localization.lua"/>
 	<Include file="Core\Core.xml"/>
-	<Include file="SippyCup.lua"/>
 	<Include file="Modules\Modules.xml"/>
-	<Include file="UI\Config.xml"/>
+	<Include file="SippyCup.lua"/>
 </Ui>

--- a/UI/Config.lua
+++ b/UI/Config.lua
@@ -3,6 +3,7 @@
 
 local L = SIPPYCUP.L;
 local SharedMedia = LibStub("LibSharedMedia-3.0");
+SIPPYCUP.Config = {};
 
 local defaultSounds = {
 	{ key = "aggro_enter_warning_state", fid = 567401 },
@@ -26,6 +27,12 @@ end
 local soundList = {}
 for _, soundName in ipairs(SharedMedia:List("sound")) do
 	soundList[soundName] = soundName
+end
+
+function SIPPYCUP.Config.TryCreateConfigFrame()
+	if not SIPPYCUP.configFrame then
+		SIPPYCUP.configFrame = CreateFrame("Frame", "SIPPYCUP_ConfigMenuFrame", UIParent, "SIPPYCUP_ConfigMenuTemplate");
+	end
 end
 
 ---AddTab creates a new tab button under the given parent frame and adds it to the parent's Tabs list.
@@ -1417,13 +1424,12 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 
 		for _, consumableData in ipairs(SIPPYCUP.Consumables.Data) do
 			if consumableData.category == categoryName then
-				local profileKey = consumableData.auraID;
+				local consumableAura = consumableData.auraID;
 				local consumableName = consumableData.name;
 				local consumableID = consumableData.itemID;
 				local consumableIcon = consumableData.icon;
 
-				local checkboxProfileKey = profileKey;
-				local checkboxConsumableName = consumableName;
+				local checkboxProfileKey = consumableAura;
 
 				categoryData[#categoryData + 1] = {
 					type = "checkbox",
@@ -1440,19 +1446,18 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 					end,
 					set = function(val)
 						SIPPYCUP.Database.UpdateSetting("profile", checkboxProfileKey, "enable", val);
-						SIPPYCUP.Popups.Toggle(checkboxConsumableName, val);
+						SIPPYCUP.Popups.Toggle(consumableName, consumableAura, val);
 					end,
 				};
 
 				-- Slider: Desired stacks (if applicable)
 				if consumableData.stacks then
-					local sliderProfileKey = profileKey;
-					local sliderConsumableName = consumableName;
+					local sliderProfileKey = consumableAura;
 
 					categoryData[#categoryData + 1] = {
 						type = "slider",
 						label = L.OPTIONS_DESIRED_STACKS,
-						tooltip = L.OPTIONS_SLIDER_TEXT and L.OPTIONS_SLIDER_TEXT:format(sliderConsumableName) or nil,
+						tooltip = L.OPTIONS_SLIDER_TEXT and L.OPTIONS_SLIDER_TEXT:format(consumableAura) or nil,
 						min = 1,
 						max = consumableData.maxStacks,
 						step = 1,
@@ -1465,7 +1470,7 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 						set = function(val)
 							SIPPYCUP.Database.UpdateSetting("profile", sliderProfileKey, "desiredStacks", val);
 							if SIPPYCUP.profile[sliderProfileKey].enable then
-								SIPPYCUP.Popups.Toggle(sliderConsumableName, true);
+								SIPPYCUP.Popups.Toggle(consumableName, consumableAura, true);
 							end
 						end,
 					};


### PR DESCRIPTION
This commit introduces the first three initial addon states: `addonLoaded`, `consumablesLoaded`, and `databaseLoaded`. Each is self-explanatory.

The addon is now slightly more protected against functions or logic running before their respective dependencies are met (such as the database or consumables).

This is a foundational step and still requires additional work.