### PR TITLE
UpdateAuraMapForConsumable (efficient single consumable aura map update)

### DIFF
--- a/Modules/Popups/Popups.lua
+++ b/Modules/Popups/Popups.lua
@@ -472,9 +472,15 @@ function SIPPYCUP.Popups.Toggle(itemName, auraID, enabled)
 	if not consumableData then
 		return;
 	end
-	SIPPYCUP.Database.RebuildAuraMap();
 
 	local profileConsumableData = SIPPYCUP.profile[consumableData.auraID];
+	if not profileConsumableData then
+		return;
+	end
+
+	-- Update aura map incrementally for this consumable
+	SIPPYCUP.Database.UpdateAuraMapForConsumable(profileConsumableData, enabled);
+
 	-- If the consumable is not enabled, kill all its associated popups and timers!
 	if not enabled then
 		RemoveDeferredActionsByLoc(consumableData.loc);


### PR DESCRIPTION
Added the `UpdateAuraMapForConsumable` function to update aura, instance, and no-aura tracking maps for individual consumables on toggle events. This reduces the overhead of rebuilding the entire aura map with `RebuildAuraMap`, which iterates over all enabled consumables.

The full rebuild remains available for bulk profile updates or loading. This change improves responsiveness and scalability of the addon’s tracking system.