### PR TITLE
State improvements - playerLogin & addonReady

### DIFF
--- a/Init.lua
+++ b/Init.lua
@@ -6,10 +6,12 @@ local _, SIPPYCUP = ...;
 
 local _state = {
 	addonLoaded = false,
+	addonReady = false,
 	consumablesLoaded = false,
 	databaseLoaded = false,
 	hasSeenFullUpdate = false,
 	inLoadingScreen = true,
+	playerLogin = false,
 	startupLoaded = false,
 };
 


### PR DESCRIPTION
This is to streamline a few things.

Some states depend on one another:
- addonLoaded only runs after databaseLoaded and consumablesLoaded are finalized.
- addonready only runs after playerLogin and startupLoaded (post-addonLoaded) are finalizd.

Hopefully handles edge situations where things ran before they reasonably have all the info/data they required.