### PR TITLE
Improve MSP code

### DIFF
--- a/Core/Utils.lua
+++ b/Core/Utils.lua
@@ -116,26 +116,6 @@ function SIPPYCUP_OUTPUT.Debug(...)
 	Print("|cnTRANSMOGRIFY_FONT_COLOR:" .. finalOutput .. "|r");
 end
 
-SIPPYCUP.Player = {};
-SIPPYCUP.Player.FullName = "";
-SIPPYCUP.Player.OOC = true;
-
-SIPPYCUP_PLAYER = {};
-
-function SIPPYCUP_PLAYER.GetFullName()
-	local name, realm = UnitFullName("player");
-	SIPPYCUP.Player.FullName = format("%s-%s", name, realm);
-end
-
-function SIPPYCUP_PLAYER.CheckOOCStatus()
-	-- msp.my.FC can be nil sometimes, mostly on login.
-	if not (msp and msp.my and msp.my.FC) then
-		return nil;
-	end
-
-	return (msp.my.FC == "1");
-end
-
 SIPPYCUP_TEXT = {};
 
 function SIPPYCUP_TEXT.Normalize(str)

--- a/Modules/MSP/MSP.lua
+++ b/Modules/MSP/MSP.lua
@@ -4,45 +4,72 @@
 SIPPYCUP.MSP = {};
 
 function SIPPYCUP.MSP.IsEnabled()
-	return msp and msp.my ~= nil;
+	return (msp ~= nil and msp.my ~= nil);
+end
+
+SIPPYCUP.MSP.FullName = "";
+SIPPYCUP.MSP.IC = false;
+
+---CheckRPStatus evaluates the player's RP status via MSP.
+---Returns whether the status changed, the previous RP status, and the newly calculated RP status.
+---Also updates SIPPYCUP.MSP.IC to the new value.
+---@return boolean changed True if RP status changed, false if unchanged.
+---@return boolean prevRP Previous RP status (false = OOC, true = IC).
+---@return boolean newRP Newly calculated RP status (false = OOC, true = IC).
+function SIPPYCUP.MSP.CheckRPStatus()
+	local prevRP = SIPPYCUP.MSP.IC or false;
+	local newRP = false;
+
+	if SIPPYCUP.MSP.IsEnabled() then
+		-- "1" means OOC = false, anything else counts as IC = true
+		newRP = msp.my.FC ~= "1";
+	end
+
+	SIPPYCUP.MSP.IC = newRP;
+	local changed = prevRP ~= newRP;
+
+	return changed, prevRP, newRP;
 end
 
 function SIPPYCUP.MSP.EnableIfAvailable()
-	if not msp or not msp.my then
+	if not SIPPYCUP.MSP.IsEnabled() then
 		return false;
 	end
 
 	-- First run we set everything in order.
-	local isOOC = SIPPYCUP_PLAYER.CheckOOCStatus();
-	SIPPYCUP.Player.OOC = isOOC;
+	local name, realm = UnitFullName("player");
+	SIPPYCUP.MSP.FullName = format("%s-%s", name, realm);
+
+	SIPPYCUP.MSP.CheckRPStatus();
 
 	-- Insert our code into the msp callback table
-	table.insert(msp.callback["updated"], function(senderID)
-		-- If MSP status checks are off, don't do anything, or if the addon startup is not done.
-		if not SIPPYCUP.global.MSPStatusCheck or not SIPPYCUP.State.startupLoaded then
-			return;
-		end
-
-		-- Sometimes this gets spammed, we only care about handling IC/OOC updates.
-		local previousIsOOC = SIPPYCUP.Player.OOC;
-		local newIsOOC = SIPPYCUP_PLAYER.CheckOOCStatus();
-		SIPPYCUP.Player.OOC = newIsOOC;
-
-		-- If RP status remains the same before vs after this check, we just skip all handling after.
-		if previousIsOOC ~= nil and newIsOOC ~= nil and previousIsOOC == newIsOOC then
-			return;
-		end
-
-		if SIPPYCUP.Player.FullName == senderID then
-			if not SIPPYCUP.Player.OOC then
-				-- Handle IC update, we check if all their enabled (even inactive ones) consumable stack sizes are in order.
-				SIPPYCUP.Consumables.RefreshStackSizes(true);
-			else
-				-- Handle OOC update, we remove all popups.
-				SIPPYCUP.Popups.HideAllRefreshPopups();
+	if not SIPPYCUP.MSP._callbackRegistered then
+		table.insert(msp.callback["updated"], function(senderID)
+			-- If MSP status checks are off, don't do anything, or if the addon startup is not done.
+			if not SIPPYCUP.global.MSPStatusCheck or not SIPPYCUP.State.startupLoaded then
+				return;
 			end
-		end
-	end);
+
+			-- Sometimes this gets spammed, we only care about handling IC/OOC updates.
+			local changed, _, isIC = SIPPYCUP.MSP.CheckRPStatus();
+
+			-- If RP status remains the same before vs after this check, we just skip all handling after.
+			if not changed then
+				return;
+			end
+
+			if SIPPYCUP.MSP.FullName == senderID then
+				if isIC then
+					-- Handle IC update, we check if all their enabled (even inactive ones) consumable stack sizes are in order.
+					SIPPYCUP.Consumables.RefreshStackSizes(true);
+				else
+					-- Handle OOC update, we remove all popups.
+					SIPPYCUP.Popups.HideAllRefreshPopups();
+				end
+			end
+		end);
+		SIPPYCUP.MSP._callbackRegistered = true;
+	end
 
 	return true;
 end

--- a/Modules/Popups/Popups.lua
+++ b/Modules/Popups/Popups.lua
@@ -584,7 +584,8 @@ local pendingCalls = {};
 ---@return nil
 function SIPPYCUP.Popups.QueuePopupAction(data,  caller)
 	-- If MSP status checks are on and the character is currently OOC, we skip everything.
-	if SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.global.MSPStatusCheck and SIPPYCUP.Player.OOC then
+	local _, _, isIC = SIPPYCUP.MSP.CheckRPStatus();
+	if SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.global.MSPStatusCheck and not isIC then
 		return;
 	end
 

--- a/Modules/Popups/Popups.lua
+++ b/Modules/Popups/Popups.lua
@@ -584,9 +584,11 @@ local pendingCalls = {};
 ---@return nil
 function SIPPYCUP.Popups.QueuePopupAction(data,  caller)
 	-- If MSP status checks are on and the character is currently OOC, we skip everything.
-	local _, _, isIC = SIPPYCUP.MSP.CheckRPStatus();
-	if SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.global.MSPStatusCheck and not isIC then
-		return;
+	if SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.global.MSPStatusCheck then
+		local _, _, isIC = SIPPYCUP.MSP.CheckRPStatus();
+		if not isIC then
+			return;
+		end
 	end
 
 	-- Use a composite key of auraID and reason so different reasons don't collide

--- a/UI/Config.lua
+++ b/UI/Config.lua
@@ -1432,7 +1432,7 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 			end,
 			set = function(val)
 				SIPPYCUP.Database.UpdateSetting("global", "MSPStatusCheck", nil, val);
-				SIPPYCUP.Player.OOC = SIPPYCUP_PLAYER.CheckOOCStatus();
+				SIPPYCUP.MSP.CheckRPStatus();
 				if val then
 					SIPPYCUP.Consumables.RefreshStackSizes(val);
 				else


### PR DESCRIPTION
There was an edge case situation when you spammed /reloads that it considered you IC even though you were not.
This was very random, and most likely due to `SIPPYCUP.Player.OOC` being accessed at times it should not.

Code is now rewritten to streamline that and behave more as expected.