### PR TITLE
Revamp Database

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -19,6 +19,7 @@ globals = {
 	"SIPPYCUP",
 	"SIPPYCUP_Addon",
 	"SippyCupDB",
+	"SippyCupCharDB",
 	"SLASH_SIPPYCUP1",
 	"SLASH_SIPPYCUP2",
 };

--- a/Core/Auras.lua
+++ b/Core/Auras.lua
@@ -114,7 +114,7 @@ local function ParseAura(updateInfo)
 
 				if not skip then
 					profileOptionData.currentInstanceID = auraInfo.auraInstanceID;
-					SIPPYCUP.Database:SetCharSetting(profileOptionData.aura, "currentInstanceID", auraInfo.auraInstanceID);
+					SIPPYCUP.Database:CommitCharState(profileOptionData.aura, profileOptionData);
 					SIPPYCUP.Database.instanceToProfile[auraInfo.auraInstanceID] = profileOptionData;
 
 					SIPPYCUP.Auras.CheckPreExpirationForSingleOption(profileOptionData);
@@ -137,9 +137,8 @@ local function ParseAura(updateInfo)
 
 					if not skip then
 						profileOptionData.currentInstanceID = auraInfo.auraInstanceID;
-						SIPPYCUP.Database:SetCharSetting(profileOptionData.aura, "currentInstanceID", auraInfo.auraInstanceID);
 						profileOptionData.currentStacks = SIPPYCUP.Auras.CalculateCurrentStacks(auraInfo, profileOptionData.aura, SIPPYCUP.Popups.Reason.UPDATE, true);
-						SIPPYCUP.Database:SetCharSetting(profileOptionData.aura, "currentStacks", profileOptionData.currentStacks);
+						SIPPYCUP.Database:CommitCharState(profileOptionData.aura, profileOptionData);
 						SIPPYCUP.Database.instanceToProfile[auraInfo.auraInstanceID] = profileOptionData;
 
 						SIPPYCUP.Auras.CancelPreExpirationTimer(nil, profileOptionData.aura, auraInstanceID);
@@ -161,8 +160,7 @@ local function ParseAura(updateInfo)
 				SIPPYCUP.Database.instanceToProfile[auraInstanceID] = nil;
 				profileOptionData.currentInstanceID = nil;
 				profileOptionData.currentStacks = 0;
-				SIPPYCUP.Database:SetCharSetting(profileOptionData.aura, "currentInstanceID", nil);
-				SIPPYCUP.Database:SetCharSetting(profileOptionData.aura, "currentStacks", 0);
+				SIPPYCUP.Database:CommitCharState(profileOptionData.aura, profileOptionData);
 
 				-- On aura removal, we remove all pre-expiration timers as that's obvious no longer relevant.
 				SIPPYCUP.Auras.CancelPreExpirationTimer(nil, profileOptionData.aura, auraInstanceID);
@@ -250,7 +248,7 @@ local function FlushAuraQueue()
 					-- Update linkage
 					SIPPYCUP.Database.instanceToProfile[removedID] = nil;
 					profileOptionData.currentInstanceID = addID;
-					SIPPYCUP.Database:SetCharSetting(auraID, "currentInstanceID", addID);
+					SIPPYCUP.Database:CommitCharState(auraID, profileOptionData);
 					SIPPYCUP.Database.instanceToProfile[addID] = profileOptionData;
 					break;
 				end
@@ -395,7 +393,7 @@ function SIPPYCUP.Auras.CheckAllActiveOptions()
 				if currentInstanceID ~= newInstanceID then
 					instanceToProfile[currentInstanceID] = nil;
 					profileOptionData.currentInstanceID = newInstanceID;
-					SIPPYCUP.Database:SetCharSetting(profileOptionData.aura, "currentInstanceID", newInstanceID);
+					SIPPYCUP.Database:CommitCharState(profileOptionData.aura, profileOptionData);
 					instanceToProfile[newInstanceID] = profileOptionData;
 
 					SIPPYCUP_OUTPUT.Debug("InstanceID Changed!|nName:", auraInfo.name, "|nSpellID:", profileOptionData.aura, "|nOld:", currentInstanceID, "|nNew:", newInstanceID);
@@ -439,7 +437,7 @@ function SIPPYCUP.Auras.CheckInstanceIDForAllActiveOptions()
 			if oldInstanceID ~= newInstanceID then
 				instanceToProfile[oldInstanceID] = nil;
 				profileOptionData.currentInstanceID = newInstanceID;
-				SIPPYCUP.Database:SetCharSetting(profileOptionData.aura, "currentInstanceID", newInstanceID);
+				SIPPYCUP.Database:CommitCharState(profileOptionData.aura, profileOptionData);
 				instanceToProfile[newInstanceID] = profileOptionData;
 
 				SIPPYCUP_OUTPUT.Debug("InstanceID Changed!|nName:", auraInfo.name, "|nSpellID:", profileOptionData.aura, "|nOld:", oldInstanceID, "|nNew:", newInstanceID);
@@ -591,6 +589,7 @@ function SIPPYCUP.Auras.CheckPreExpirationForSingleOption(profileOptionData, min
 	end
 
 	profileOptionData.currentStacks = SIPPYCUP.Auras.CalculateCurrentStacks(auraInfo, auraID, 0, active);
+	SIPPYCUP.Database:CommitCharState(auraID, profileOptionData);
 
 	-- Some stack items can be pre-expired for refresh but ONLY if the current stacks == maxStacks
 	if optionData.stacks and profileOptionData.currentStacks ~= optionData.maxStacks then

--- a/Core/Auras.lua
+++ b/Core/Auras.lua
@@ -27,7 +27,7 @@ end
 
 ---SkipDuplicatePrismUnitAura determines if a prism-type aura update should be ignored.
 ---Duplicates are ignored only if they fire within a very short timeframe.
----@param profileOptionData SippyCupCharSettings The option profile data.
+---@param profileOptionData SippyCupProfile The option profile data.
 ---@param auraInstanceID number The aura instance ID being processed.
 ---@return boolean skip True if this aura update should be skipped as a duplicate.
 local function SkipDuplicatePrismUnitAura(profileOptionData, auraInstanceID)
@@ -53,7 +53,7 @@ local function SkipDuplicatePrismUnitAura(profileOptionData, auraInstanceID)
 end
 
 ---QueueAuraAction enqueues a popup action for aura changes.
----@param profileOptionData table The option profile data.
+---@param profileOptionData SippyCupProfile The option profile data.
 ---@param auraInfo table? The aura information, or nil if removed.
 ---@param reason number The reason for the popup (ADDITION, REMOVAL, etc).
 ---@param source string The source description of the action.
@@ -562,7 +562,7 @@ function SIPPYCUP.Auras.CheckPreExpirationForAllActiveOptions(minSeconds)
 end
 
 ---CheckPreExpirationForSingleOption sets up pre-expiration warnings for aura-based options.
----@param profileOptionData SippyCupCharSettings Profile data for the option.
+---@param profileOptionData SippyCupProfile Profile data for the option.
 ---@param minSeconds number? Time window to check ahead, defaults to 180.
 ---@return boolean preExpireFired True if a pre-expiration popup was fired.
 function SIPPYCUP.Auras.CheckPreExpirationForSingleOption(profileOptionData, minSeconds)

--- a/Core/Auras.lua
+++ b/Core/Auras.lua
@@ -27,7 +27,7 @@ end
 
 ---SkipDuplicatePrismUnitAura determines if a prism-type aura update should be ignored.
 ---Duplicates are ignored only if they fire within a very short timeframe.
----@param profileOptionData SIPPYCUPProfileOption The option profile data.
+---@param profileOptionData SippyCupCharSettings The option profile data.
 ---@param auraInstanceID number The aura instance ID being processed.
 ---@return boolean skip True if this aura update should be skipped as a duplicate.
 local function SkipDuplicatePrismUnitAura(profileOptionData, auraInstanceID)
@@ -108,12 +108,13 @@ local function ParseAura(updateInfo)
 	local added = updateInfo.addedAuras;
 	if added then
 		for _, auraInfo in ipairs(added) do
-			local profileOptionData = SIPPYCUP.Database.FindMatchingProfile(auraInfo.spellId);
+			local profileOptionData = SIPPYCUP.Database:FindMatchingProfile(auraInfo.spellId);
 			if profileOptionData and profileOptionData.enable then
 				local skip = SkipDuplicatePrismUnitAura(profileOptionData, auraInfo.auraInstanceID);
 
 				if not skip then
 					profileOptionData.currentInstanceID = auraInfo.auraInstanceID;
+					SIPPYCUP.Database:SetCharSetting(profileOptionData.aura, "currentInstanceID", auraInfo.auraInstanceID);
 					SIPPYCUP.Database.instanceToProfile[auraInfo.auraInstanceID] = profileOptionData;
 
 					SIPPYCUP.Auras.CheckPreExpirationForSingleOption(profileOptionData);
@@ -128,7 +129,7 @@ local function ParseAura(updateInfo)
 	local updated = updateInfo.updatedAuraInstanceIDs;
 	if updated then
 		for _, auraInstanceID in ipairs(updated) do
-			local profileOptionData = SIPPYCUP.Database.FindMatchingProfile(nil, auraInstanceID);
+			local profileOptionData = SIPPYCUP.Database:FindMatchingProfile(nil, auraInstanceID);
 			if profileOptionData and profileOptionData.enable then
 				local auraInfo = GetAuraDataByAuraInstanceID("player", auraInstanceID);
 				if auraInfo then
@@ -136,6 +137,9 @@ local function ParseAura(updateInfo)
 
 					if not skip then
 						profileOptionData.currentInstanceID = auraInfo.auraInstanceID;
+						SIPPYCUP.Database:SetCharSetting(profileOptionData.aura, "currentInstanceID", auraInfo.auraInstanceID);
+						profileOptionData.currentStacks = SIPPYCUP.Auras.CalculateCurrentStacks(auraInfo, profileOptionData.aura, SIPPYCUP.Popups.Reason.UPDATE, true);
+						SIPPYCUP.Database:SetCharSetting(profileOptionData.aura, "currentStacks", profileOptionData.currentStacks);
 						SIPPYCUP.Database.instanceToProfile[auraInfo.auraInstanceID] = profileOptionData;
 
 						SIPPYCUP.Auras.CancelPreExpirationTimer(nil, profileOptionData.aura, auraInstanceID);
@@ -152,10 +156,13 @@ local function ParseAura(updateInfo)
 	local removed = updateInfo.removedAuraInstanceIDs;
 	if removed then
 		for _, auraInstanceID in ipairs(removed) do
-			local profileOptionData = SIPPYCUP.Database.FindMatchingProfile(nil, auraInstanceID);
+			local profileOptionData = SIPPYCUP.Database:FindMatchingProfile(nil, auraInstanceID);
 			if profileOptionData and profileOptionData.enable and profileOptionData.currentInstanceID then
 				SIPPYCUP.Database.instanceToProfile[auraInstanceID] = nil;
 				profileOptionData.currentInstanceID = nil;
+				profileOptionData.currentStacks = 0;
+				SIPPYCUP.Database:SetCharSetting(profileOptionData.aura, "currentInstanceID", nil);
+				SIPPYCUP.Database:SetCharSetting(profileOptionData.aura, "currentStacks", 0);
 
 				-- On aura removal, we remove all pre-expiration timers as that's obvious no longer relevant.
 				SIPPYCUP.Auras.CancelPreExpirationTimer(nil, profileOptionData.aura, auraInstanceID);
@@ -243,6 +250,7 @@ local function FlushAuraQueue()
 					-- Update linkage
 					SIPPYCUP.Database.instanceToProfile[removedID] = nil;
 					profileOptionData.currentInstanceID = addID;
+					SIPPYCUP.Database:SetCharSetting(auraID, "currentInstanceID", addID);
 					SIPPYCUP.Database.instanceToProfile[addID] = profileOptionData;
 					break;
 				end
@@ -387,6 +395,7 @@ function SIPPYCUP.Auras.CheckAllActiveOptions()
 				if currentInstanceID ~= newInstanceID then
 					instanceToProfile[currentInstanceID] = nil;
 					profileOptionData.currentInstanceID = newInstanceID;
+					SIPPYCUP.Database:SetCharSetting(profileOptionData.aura, "currentInstanceID", newInstanceID);
 					instanceToProfile[newInstanceID] = profileOptionData;
 
 					SIPPYCUP_OUTPUT.Debug("InstanceID Changed!|nName:", auraInfo.name, "|nSpellID:", profileOptionData.aura, "|nOld:", currentInstanceID, "|nNew:", newInstanceID);
@@ -430,6 +439,7 @@ function SIPPYCUP.Auras.CheckInstanceIDForAllActiveOptions()
 			if oldInstanceID ~= newInstanceID then
 				instanceToProfile[oldInstanceID] = nil;
 				profileOptionData.currentInstanceID = newInstanceID;
+				SIPPYCUP.Database:SetCharSetting(profileOptionData.aura, "currentInstanceID", newInstanceID);
 				instanceToProfile[newInstanceID] = profileOptionData;
 
 				SIPPYCUP_OUTPUT.Debug("InstanceID Changed!|nName:", auraInfo.name, "|nSpellID:", profileOptionData.aura, "|nOld:", oldInstanceID, "|nNew:", newInstanceID);
@@ -541,7 +551,7 @@ end
 ---@return nil
 function SIPPYCUP.Auras.CheckPreExpirationForAllActiveOptions(minSeconds)
 	-- Data sent through/around loading screens will not be reliable, so skip that.
-	if SIPPYCUP.States.loadingScreen or not SIPPYCUP.global.PreExpirationChecks then
+	if SIPPYCUP.States.loadingScreen or not SIPPYCUP.Database:GetGlobalSetting("PreExpirationChecks") then
 		return;
 	end
 
@@ -552,14 +562,14 @@ function SIPPYCUP.Auras.CheckPreExpirationForAllActiveOptions(minSeconds)
 end
 
 ---CheckPreExpirationForSingleOption sets up pre-expiration warnings for aura-based options.
----@param profileOptionData SIPPYCUPProfileOption Profile data for the option.
+---@param profileOptionData SippyCupCharSettings Profile data for the option.
 ---@param minSeconds number? Time window to check ahead, defaults to 180.
 ---@return boolean preExpireFired True if a pre-expiration popup was fired.
 function SIPPYCUP.Auras.CheckPreExpirationForSingleOption(profileOptionData, minSeconds)
 	local preExpireFired = false;
 
 	-- If pre-expiration checks can't be done, why are we even here?
-	if SIPPYCUP.States.loadingScreen or not SIPPYCUP.global.PreExpirationChecks then
+	if SIPPYCUP.States.loadingScreen or not SIPPYCUP.Database:GetGlobalSetting("PreExpirationChecks") then
 		return preExpireFired;
 	end
 
@@ -594,12 +604,12 @@ function SIPPYCUP.Auras.CheckPreExpirationForSingleOption(profileOptionData, min
 
 	if profileOptionData.isPrism then
 		if profileOptionData.usesCharges then -- reflecting prism
-			preOffset = SIPPYCUP.global.ReflectingPrismPreExpirationLeadTimer * 60;
+			preOffset = SIPPYCUP.Database:GetGlobalSetting("ReflectingPrismPreExpirationLeadTimer") * 60;
 		else -- projection prism
-			preOffset = SIPPYCUP.global.ProjectionPrismPreExpirationLeadTimer * 60;
+			preOffset = SIPPYCUP.Database:GetGlobalSetting("ProjectionPrismPreExpirationLeadTimer") * 60;
 		end
 	else -- Global
-		preOffset = SIPPYCUP.global.PreExpirationLeadTimer * 60;
+		preOffset = SIPPYCUP.Database:GetGlobalSetting("PreExpirationLeadTimer") * 60;
 	end
 
 	-- If the option only lasts for less than user set, we need to change it.
@@ -644,7 +654,7 @@ end
 
 ---@param auraInfo table? Information about the aura, or nil if not present.
 ---@param auraID number The aura ID.
----@param reason number The situation to calculate stacks for (0 - add/update, 1 = removal, 2 = pre-expire, 3 = toggle)
+---@param reason number The situation to calculate stacks for (0 - add/update, 1 = removal, 2 = pre-expire, 3 = toggle, 4 = startup)
 ---@param active boolean Whether the aura is currently active (false = inactive, true = active).
 ---@return number currentStacks The current stacks for this aura.
 function SIPPYCUP.Auras.CalculateCurrentStacks(auraInfo, auraID, reason, active)
@@ -668,9 +678,9 @@ function SIPPYCUP.Auras.CalculateCurrentStacks(auraInfo, auraID, reason, active)
 	-- Case 2: Pre-expiration (return maxStacks - 1 for stackable that require 1 re-application for full)
 	if reason == SIPPYCUP.Popups.Reason.PRE_EXPIRATION then
 		local optionData = SIPPYCUP.Options.ByAuraID[auraID];
-		local profileOptionData = SIPPYCUP.Profile[auraID];
+		local currentStacks = SIPPYCUP.Database:GetCharSetting(auraID, "currentStacks");
 
-		if optionData.stacks and profileOptionData.currentStacks == optionData.maxStacks then
+		if optionData.stacks and currentStacks == optionData.maxStacks then
 			return optionData.maxStacks - 1;
 		end
 

--- a/Core/Database.lua
+++ b/Core/Database.lua
@@ -530,6 +530,7 @@ end
 ---@return nil
 function Database:SetProfile(profileName)
 	if not profileName or profileName == "" then return; end
+	if profileName == self:GetProfileName() then return; end
 
 	local db = SippyCupDB;
 	db.profiles[profileName] = db.profiles[profileName] or {};
@@ -544,7 +545,7 @@ function Database:SetProfile(profileName)
 
 	SIPPYCUP.Options.RefreshStackSizes(
 		SIPPYCUP.MSP.IsEnabled() and self:GetGlobalSetting("MSPStatusCheck"),
-		false, true
+		false
 	);
 end
 
@@ -620,7 +621,7 @@ function Database:CopyProfile(sourceName)
 
 	SIPPYCUP.Options.RefreshStackSizes(
 		SIPPYCUP.MSP.IsEnabled() and self:GetGlobalSetting("MSPStatusCheck"),
-		false, true
+		false
 	);
 
 	return true;

--- a/Core/Database.lua
+++ b/Core/Database.lua
@@ -463,6 +463,20 @@ function Database:LoadFromSaved()
 	end
 end
 
+---Re-resolves and re-points currentProfile based on the current player key.
+---@return nil
+function Database:ResolveActiveProfile()
+	local db = SippyCupDB;
+	if not db then return; end;
+
+	local playerKey = SIPPYCUP_UTILS.GetUnitName() or "Unknown";
+	local profileName = db.profileKeys[playerKey] or "Default";
+
+	db.profiles[profileName] = db.profiles[profileName] or {};
+	self.currentProfile = db.profiles[profileName];
+	db.profileKeys[playerKey] = profileName;
+end
+
 ---Refreshes the config UI if the configuration frame is loaded.
 ---@return nil
 function Database:refreshUI()

--- a/Core/Database.lua
+++ b/Core/Database.lua
@@ -1,82 +1,17 @@
 -- Copyright The Sippy Cup Authors
 -- SPDX-License-Identifier: Apache-2.0
 
-local L = SIPPYCUP.L;
-SIPPYCUP.Database = {};
----@type table<number, SIPPYCUPProfileOption>
-SIPPYCUP.Profile = {};
-
----Copies keys from source to target only if target key is nil (recursive).
----@param source table Source table to copy defaults from.
----@param target table Target table to copy defaults into.
----@return nil
-local function DeepCopyDefaults(source, target)
-	for k, v in pairs(source) do
-		local tgt = target[k];
-		if type(v) == "table" then
-			if not tgt then
-				tgt = {};
-				target[k] = tgt;
-			end
-			DeepCopyDefaults(v, tgt);
-		elseif tgt == nil then
-			target[k] = v;
-		end
-	end
-end
-
----Copies keys from source to target, overwriting target keys (recursive).
----@param source table Source table.
----@param target table Target table to merge into.
----@return nil
-local function DeepMerge(source, target)
-	for k, v in pairs(source) do
-		local tgt = target[k];
-		if type(v) == "table" then
-			if not tgt then
-				tgt = {};
-				target[k] = tgt;
-			end
-			DeepMerge(v, tgt);
-		else
-			target[k] = v;
-		end
-	end
-end
-
----Returns a minimal table containing only values from current that differ from default.
----@param current table The table with current values.
----@param default table? Optional default table to compare against.
----@return table minimal The minimal table with only differing values.
-local function GetMinimalTable(current, default)
-	local minimal;
-	for k, v in pairs(current) do
-		local defVal = default and default[k];
-		if type(v) == "table" and type(defVal) == "table" then
-			local nested = GetMinimalTable(v, defVal);
-			-- Only include nested tables if they have keys (non-empty)
-			if next(nested) then
-				minimal = minimal or {};
-				minimal[k] = nested;
-			end
-		elseif v ~= defVal then
-			minimal = minimal or {};
-			minimal[k] = v;
-		end
-	end
-	return minimal or {};
-end
-
----Default saved variable structure for the SippyCup addon.
----Contains both global options and profile-specific option settings.
----@class SIPPYCUPDefaults
----@field global SIPPYCUPGlobalSettings Global settings shared across all profiles.
----@field profiles table<string, table<string, SIPPYCUPProfileOption>> Table of profiles, each mapping to a table of profile keys.
+---@class SippyCupDatabase
+---@field currentProfile SippyCupProfile?
+---@field defaults SippyCupProfile
+---@field globalDefaults SippyCupGlobal
+local Database = {};
 
 ---Global addon settings shared across all user profiles.
----@class SIPPYCUPGlobalSettings
+---@class SippyCupGlobal
 ---@field AlertSound boolean Whether alert sound is enabled.
 ---@field AlertSoundID string The sound ID to play for alerts.
+---@field DebugOutput boolean Whether debug output is enabled.
 ---@field FlashTaskbar boolean Whether to flash the taskbar on alerts.
 ---@field Flyway SIPPYCUPFlyway Database patch versioning and migration tracking.
 ---@field InsufficientReminder boolean Whether to show a reminder if not enough consumables are found.
@@ -101,70 +36,58 @@ end
 ---@field CurrentBuild integer The last applied database patch version. Starts at 0.
 ---@field Log string A text log of the last patch operation, or "" if none.
 
----@type SIPPYCUPDefaults
-SIPPYCUP.Database.defaults = {
-	global = {
-		AlertSound = true,
-		AlertSoundID = "fx_ship_bell_chime_02",
-		DebugOutput = false,
-		FlashTaskbar = true,
-		Flyway = {
-			CurrentBuild = 0,
-			Log = "",
-		},
-		InsufficientReminder = false,
-		MinimapButton = {
-			Hide = false,
-			ShowAddonCompartmentButton = true,
-		},
-		MSPStatusCheck = true,
-		NewFeatureNotification = true,
-		PopupPosition = "TOP",
-		PreExpirationChecks = true,
-		PreExpirationLeadTimer = 1,
-		ProjectionPrismPreExpirationLeadTimer = 5,
-		ReflectingPrismPreExpirationLeadTimer = 3,
-		UseToyCooldown = true,
-		WelcomeMessage = true,
+---Default saved variable structure for the SippyCup addon.
+---Contains both global options and profile-specific option settings.
+---@class SIPPYCUPDefaults
+---@field global SippyCupGlobal Global settings shared across all profiles.
+
+---@type SippyCupGlobal
+local GLOBAL_DEFAULTS = {
+	AlertSound = true,
+	AlertSoundID = "fx_ship_bell_chime_02",
+	DebugOutput = false,
+	FlashTaskbar = true,
+	Flyway = {
+		CurrentBuild = 0,
+		Log = "",
 	},
-	profiles = {
-		Default = {},  -- will hold all options per profile
+	InsufficientReminder = false,
+	MinimapButton = {
+		Hide = false,
+		ShowAddonCompartmentButton = true,
 	},
+	MSPStatusCheck = true,
+	NewFeatureNotification = true,
+	PopupPosition = "TOP",
+	PreExpirationChecks = true,
+	PreExpirationLeadTimer = 1,
+	ProjectionPrismPreExpirationLeadTimer = 5,
+	ReflectingPrismPreExpirationLeadTimer = 3,
+	UseToyCooldown = true,
+	WelcomeMessage = true,
 };
 
-local defaults = SIPPYCUP.Database.defaults;
-
----PersistCurrentProfile saves the current runtime profile as minimal differences to saved variables.
----@return nil
-local function PersistCurrentProfile()
-	local currentProfileName = SIPPYCUP.Database.GetCurrentProfileName();
-	if not currentProfileName or not SIPPYCUP.Profile then return; end
-
-	local defaultProfile = defaults.profiles.Default or {};
-	local minimal = GetMinimalTable(SIPPYCUP.Profile, defaultProfile);
-	SIPPYCUP.db.profiles[currentProfileName] = minimal;
-end
-
 ---Represents a single option's tracking settings within a user profile.
----@class SIPPYCUPProfileOption: table
+---@class SippyCupProfile
 ---@field enable boolean Whether the option is enabled for tracking.
----@field desiredStacks number Number of stacks the user wants to maintain.
----@field currentInstanceID number? Aura instance ID currently being tracked (if any).
----@field currentStacks number Current number of detected stacks.
+---@field desiredStacks integer Number of stacks the user wants to maintain.
 ---@field aura number The associated aura ID for this option.
----@field castAura number The associated cast aura ID, if none is set then use aura ID.
+---@field castAura number? The associated cast aura ID. If none is set, aura ID is used.
 ---@field untrackableByAura boolean Whether this option can be tracked via its aura or not.
----@field type string Whether this option is a consumable (0) or toy (1).
+---@field type integer Whether this option is a consumable (0) or toy (1).
 ---@field isPrism boolean Whether this option is considered a prism.
 ---@field instantUpdate boolean Whether the instant UNIT_AURA update has already happened right after the addition (prisms).
----@field usesCharges boolean Whether this option uses charges (generally reflecting prism).
+---@field usesCharges boolean? Whether this option uses charges (generally reflecting prism).
+
+---Default profile options keyed by aura ID
+---@type table<number, SippyCupProfile>
+local DEFAULT_PROFILE = {};
 
 ---Populate the default option's table keyed by aura ID, with all known entries from SIPPYCUP.Options.Data.
 ---This defines initial tracking settings for each option by its aura ID key.
 ---@return nil
-local function PopulateDefaultOptions()
+local function PopulateDefaultProfileOptions()
 	local optionsData = SIPPYCUP.Options.Data;
-	local defaultsProfile = defaults.profiles.Default;
 	for i = 1, #optionsData do
 		local option = optionsData[i];
 		local spellID = option.auraID;
@@ -177,11 +100,9 @@ local function PopulateDefaultOptions()
 
 		if spellID then
 			-- Use auraID as the key, not profileKey
-			defaultsProfile[spellID] = {
+			DEFAULT_PROFILE[spellID] = {
 				enable = false,
 				desiredStacks = 1,
-				currentInstanceID = nil,
-				currentStacks = 0,
 				aura = spellID,
 				castAura = castSpellID,
 				untrackableByAura = untrackableByAura,
@@ -194,100 +115,215 @@ local function PopulateDefaultOptions()
 	end
 end
 
-PopulateDefaultOptions();
+---@class SippyCupCharSettings
+---@field currentInstanceID number? Aura instance ID currently being tracked (if any).
+---@field currentStacks integer Current number of detected stacks.
+---@field currentItemID number? The item ID currently being used for this option.
+---@field lastItemCount integer Last known item count for this option.
 
----@type table<number, SIPPYCUPProfileOption>
-SIPPYCUP.Database.auraToProfile = {}; -- auraID --> profile data
----@type table<number, SIPPYCUPProfileOption>
-SIPPYCUP.Database.instanceToProfile = {}; -- instanceID --> profile data
----@type table<number, SIPPYCUPProfileOption>
-SIPPYCUP.Database.untrackableByAuraProfile = {}; -- itemID --> profile data (only if no aura)
----@type table<number, SIPPYCUPProfileOption>
-SIPPYCUP.Database.castAuraToProfile = {}; -- castAuraID (if different) / auraID --> profile data
+---Default character settings keyed by aura ID
+---@type table<number, SippyCupCharSettings>
+local DEFAULT_CHAR = {};
 
+local function PopulateDefaultCharOptions()
+	local optionsData = SIPPYCUP.Options.Data;
+	for i = 1, #optionsData do
+		local option = optionsData[i];
+		local spellID = option.auraID;
+
+		if spellID then
+			-- Use auraID as the key, not profileKey
+			DEFAULT_CHAR[spellID] = {
+				currentInstanceID = nil,
+				currentStacks = 0,
+				currentItemID = nil,
+				lastItemCount = 0,
+			};
+		end
+	end
+end
+
+Database.currentProfile = nil;
+Database.globalDefaults = SIPPYCUP_UTILS.DeepCopy(GLOBAL_DEFAULTS);
+
+---Returns a new table containing all keys from `base`, with keys from `override` applied on top.
+---@param base table
+---@param override table
+---@return table
+local function mergeTables(base, override)
+	-- start with defaults
+	local result = SIPPYCUP_UTILS.ShallowCopy(base);
+	-- apply profile overrides (including keys not in defaults)
+	for k, v in pairs(override) do
+		result[k] = v;
+	end
+	return result;
+end
+
+---Returns a pruned copy of `value` containing only keys that differ from `def`.
+---Returns nil if no keys differ (signals "same as default, don't store").
+---Always returns the table itself if `def` is nil (no defaults to compare against).
+---@param value table
+---@param def table?
+---@return table?
+local function pruneToDefaults(value, def)
+	local newTable = {};
+	-- store only keys that differ from defaults
+	for k, v in pairs(value) do
+		if not def or def[k] ~= v then
+			newTable[k] = v;
+		end
+	end
+	-- store table only if there is at least one diff
+	return next(newTable) and newTable or nil;
+end
+
+---Removes any stored values from a profile that are identical to their defaults.
+---Primitives matching defaults are nilled; table values are pruned key-by-key
+---and removed entirely when every key matches the default.
+---@param profile table
+local function pruneProfile(profile)
+	for key, value in pairs(profile) do
+		local def = DEFAULT_PROFILE[key];
+		if def == nil then -- luacheck: ignore 542 (empty if branch)
+			-- No default exists for this key; leave it untouched.
+		elseif type(value) == "table" then
+			if type(def) == "table" then
+				profile[key] = pruneToDefaults(value, def);
+			end
+		elseif value == def then
+			profile[key] = nil;
+		end
+	end
+end
+
+---@type table<number, SippyCupProfile>
+Database.auraToProfile = {}; -- auraID --> profile data
+---@type table<number, SippyCupProfile>
+Database.instanceToProfile = {}; -- instanceID --> profile data
+---@type table<number, SippyCupProfile>
+Database.untrackableByAuraProfile = {}; -- itemID --> profile data (only if no aura)
+---@type table<number, SippyCupProfile>
+Database.castAuraToProfile = {}; -- castAuraID (if different) / auraID --> profile data
 
 ---RebuildAuraMap rebuilds internal lookup tables for aura and instance-based option tracking.
 ---@return nil
-function SIPPYCUP.Database.RebuildAuraMap()
+function Database:RebuildAuraMap()
 	-- Reset fast lookup tables
-	local db = SIPPYCUP.Database;
-	wipe(db.auraToProfile);
-	wipe(db.instanceToProfile);
-	wipe(db.untrackableByAuraProfile);
-	wipe(db.castAuraToProfile);
+	wipe(self.auraToProfile);
+	wipe(self.instanceToProfile);
+	wipe(self.untrackableByAuraProfile);
+	wipe(self.castAuraToProfile);
 
-	for _, profileOptionData in pairs(SIPPYCUP.Profile) do
-		if profileOptionData.enable and profileOptionData.aura then
-			local auraID = profileOptionData.aura;
-			db.auraToProfile[auraID] = profileOptionData;
-			local castAuraID = profileOptionData.castAura;
-			db.castAuraToProfile[castAuraID] = profileOptionData;
+	local GetAuraDataByAuraInstanceID = C_UnitAuras.GetAuraDataByAuraInstanceID;
 
-			-- Update instance ID if aura is currently active
+	-- Iterate over all defaults to ensure full merged profile
+	for auraID, defaultData in pairs(self.defaults or {}) do
+		local profileOverride = (self.currentProfile or {})[auraID] or {};
+		-- Merge default values with any user overrides
+		local profileOptionData = mergeTables(defaultData, profileOverride);
+
+		-- Only track enabled auras
+		if profileOptionData.enable and auraID then
+			self.auraToProfile[auraID] = profileOptionData;
+
+			local castAuraID = profileOptionData.castAura or auraID;
+			self.castAuraToProfile[castAuraID] = profileOptionData;
+
 			local auraInfo;
-			if canaccessvalue == nil or canaccessvalue(auraID) then
+			if profileOptionData.currentInstanceID then
+				auraInfo = GetAuraDataByAuraInstanceID("player", profileOptionData.currentInstanceID);
+			end
+			if not auraInfo then
 				auraInfo = C_UnitAuras.GetPlayerAuraBySpellID(auraID);
 			end
-			local instanceID = auraInfo and auraInfo.auraInstanceID;
-			profileOptionData.currentInstanceID = instanceID;
-			if instanceID then
-				db.instanceToProfile[instanceID] = profileOptionData;
+
+			profileOptionData.currentInstanceID = auraInfo and auraInfo.auraInstanceID or nil;
+			profileOptionData.currentStacks = SIPPYCUP.Auras.CalculateCurrentStacks(
+				auraInfo, auraID, SIPPYCUP.Popups.Reason.STARTUP, auraInfo ~= nil
+			);
+
+			-- persist to character DB
+			self:SetCharSetting(auraID, "currentInstanceID", profileOptionData.currentInstanceID);
+			self:SetCharSetting(auraID, "currentStacks", profileOptionData.currentStacks);
+
+			if profileOptionData.currentInstanceID then
+				self.instanceToProfile[profileOptionData.currentInstanceID] = profileOptionData;
 			end
 
 			-- Handle options that are trackable without auras (via itemID)
 			if profileOptionData.untrackableByAura then
 				local optionData = SIPPYCUP.Options.ByAuraID[auraID];
 				if optionData and optionData.itemID then
-					db.untrackableByAuraProfile[optionData.itemID] = profileOptionData;
+					self.untrackableByAuraProfile[optionData.itemID] = profileOptionData;
 				end
+			end
+		end
+	end
+
+	-- Prune char data for options not enabled in the current profile
+	if self.currentChar then
+		for auraID in pairs(self.currentChar) do
+			if not self.auraToProfile[auraID] then
+				self.currentChar[auraID] = nil;
 			end
 		end
 	end
 end
 
----UpdateAuraMapForOption updates or removes a single profile's entries in the aura, instance, and noAura mappings.
----@param profileOptionData SIPPYCUPProfileOption The profile data to update.
----@param enabled boolean Whether the profile is enabled or disabled.
----@return nil
-function SIPPYCUP.Database.UpdateAuraMapForOption(profileOptionData, enabled)
-	if not profileOptionData or not profileOptionData.aura then
-		return;
-	end
+---UpdateAuraMapForOption updates or removes a profile option from aura/instance/item lookup tables.
+---@param profileOptionData SippyCupCharSettings The profile data to update.
+---@param enabled boolean Whether the option is enabled or disabled.
+function Database:UpdateAuraMapForOption(profileOptionData, enabled)
+	if not profileOptionData or not profileOptionData.aura then return; end
 
-	local db = SIPPYCUP.Database;
 	local auraID = profileOptionData.aura;
+	local castAuraID = profileOptionData.castAura or auraID;
 	local optionData = SIPPYCUP.Options.ByAuraID[auraID];
 
 	if enabled then
-		-- Add/update auraToProfile
-		db.auraToProfile[auraID] = profileOptionData;
+		-- Add/update auraToProfile and castAuraToProfile
+		self.auraToProfile[auraID] = profileOptionData;
+		self.castAuraToProfile[castAuraID] = profileOptionData;
 
 		-- Update instanceToProfile if aura is currently active
 		local auraInfo = C_UnitAuras.GetPlayerAuraBySpellID(auraID);
 		local instanceID = auraInfo and auraInfo.auraInstanceID;
 		profileOptionData.currentInstanceID = instanceID;
+		profileOptionData.currentStacks = SIPPYCUP.Auras.CalculateCurrentStacks(
+			auraInfo, auraID, SIPPYCUP.Popups.Reason.STARTUP, auraInfo ~= nil
+		);
+
+		-- persist to character DB
+		self:SetCharSetting(auraID, "currentInstanceID", profileOptionData.currentInstanceID);
+		self:SetCharSetting(auraID, "currentStacks", profileOptionData.currentStacks);
+
 		if instanceID then
-			db.instanceToProfile[instanceID] = profileOptionData;
+			self.instanceToProfile[instanceID] = profileOptionData;
 		end
 
-		-- Update untrackableByAuraProfile if applicable
+		-- Map itemID for options trackable without an aura
 		if profileOptionData.untrackableByAura and optionData and optionData.itemID then
-			db.untrackableByAuraProfile[optionData.itemID] = profileOptionData;
+			self.untrackableByAuraProfile[optionData.itemID] = profileOptionData;
 		end
 	else
-		-- Remove from auraToProfile
-		db.auraToProfile[auraID] = nil;
+		-- Remove from all lookup tables
+		self.auraToProfile[auraID] = nil;
+		self.castAuraToProfile[castAuraID] = nil;
 
-		-- Remove from instanceToProfile if currentInstanceID is set
 		local instanceID = profileOptionData.currentInstanceID;
 		if instanceID then
-			db.instanceToProfile[instanceID] = nil;
+			self.instanceToProfile[instanceID] = nil;
 			profileOptionData.currentInstanceID = nil;
 		end
 
-		-- Remove from untrackableByAuraProfile if applicable
+		profileOptionData.currentStacks = 0;
+		-- persist to character DB
+		self:SetCharSetting(auraID, "currentInstanceID", nil);
+		self:SetCharSetting(auraID, "currentStacks", 0);
+
 		if profileOptionData.untrackableByAura and optionData and optionData.itemID then
-			db.untrackableByAuraProfile[optionData.itemID] = nil;
+			self.untrackableByAuraProfile[optionData.itemID] = nil;
 		end
 	end
 end
@@ -296,504 +332,489 @@ end
 ---@param spellId number? Spell ID to match `auraToProfile`.
 ---@param instanceID number? Aura instance ID to match `instanceToProfile`.
 ---@param itemID number? Item ID to match `untrackableByAuraProfile`.
----@return SIPPYCUPProfileOption? profileOptionData
-function SIPPYCUP.Database.FindMatchingProfile(spellId, instanceID, itemID)
-	local db = SIPPYCUP.Database;
-
+---@return SippyCupCharSettings? profileOptionData
+function Database:FindMatchingProfile(spellId, instanceID, itemID)
 	if canaccessvalue == nil or canaccessvalue(spellId) then
 		if spellId ~= nil then
-			return db.auraToProfile[spellId];
+			return self.auraToProfile[spellId];
 		end
 	end
 
 	if instanceID ~= nil then
-		return db.instanceToProfile[instanceID];
+		return self.instanceToProfile[instanceID];
 	elseif itemID ~= nil then
-		return db.untrackableByAuraProfile[itemID];
+		return self.untrackableByAuraProfile[itemID];
 	end
 
 	return nil;
 end
 
-local categories = { "Appearance", "Effect", "Handheld", "Placement", "Prism", "Size" };
-
--- Sort `categories` in-place by their localized title:
-table.sort(categories, function(a, b)
-	local locA = L["OPTIONS_TAB_" .. string.upper(a) .. "_TITLE"];
-	local locB = L["OPTIONS_TAB_" .. string.upper(b) .. "_TITLE"];
-	return SIPPYCUP_TEXT.Normalize(locA:lower()) < SIPPYCUP_TEXT.Normalize(locB:lower());
-end);
-
----Gets a value from the current profile, falling back to defaults.
----@param key string
----@return any
-function SIPPYCUP.Database.GetSetting(key)
-	local profile = SIPPYCUP.Profile;
-	local defaultsProfile = SIPPYCUP.Database.defaults.profiles.Default;
-
-	if not defaultsProfile then return nil; end
-	if not profile then return defaultsProfile[key]; end
-
-	local value = profile[key];
-	if value == nil then
-		local def = defaultsProfile[key];
-		if type(def) == "table" then
-			profile[key] = {};
-			for k, v in pairs(def) do
-				profile[key][k] = v;
-			end
-			value = profile[key];
-		else
-			value = def;
-		end
-	end
-
-	return value;
-end
-
----Sets a value in the current profile.
----@param key string
----@param value any
-function SIPPYCUP.Database.SetSetting(key, value)
-	local profile = SIPPYCUP.Profile;
-	if not profile then return; end
-
-	local defaultsProfile = SIPPYCUP.Database.defaults.profiles.Default;
-	local def = defaultsProfile and defaultsProfile[key];
-
-	if type(value) == "table" then
-		profile[key] = profile[key] or {};
-		for k, v in pairs(value) do
-			profile[key][k] = v;
-		end
-	elseif value == def then
-		profile[key] = nil;
-	else
-		profile[key] = value;
-	end
-
-	-- Persist to saved variables
-	local profileName = SIPPYCUP.Database.GetCurrentProfileName();
-	if profileName then
-		local defaultProfile = SIPPYCUP.Database.defaults.profiles.Default or {};
-		local minimal = GetMinimalTable(profile, defaultProfile);
-		SIPPYCUP.db.profiles[profileName] = minimal;
-	end
-end
-
----Gets a value from the global database, falling back to defaults.
----@param key string
----@return any
-function SIPPYCUP.Database.GetGlobalSetting(key)
-	local global = SIPPYCUP.global;
-	local def = SIPPYCUP.Database.defaults.global[key];
-
-	if global[key] == nil then
-		if type(def) == "table" then
-			global[key] = {};
-			local t = global[key];
-			for k, v in pairs(def) do
-				t[k] = t[k] or v;
-			end
-		else
-			global[key] = def;
-		end
-	end
-
-	return global[key];
-end
-
----Sets a value in the global database.
----@param key string
----@param value any
-function SIPPYCUP.Database.SetGlobalSetting(key, value)
-	local global = SIPPYCUP.global;
-
-	if type(value) == "table" then
-		global[key] = global[key] or {};
-		for k, v in pairs(value) do
-			global[key][k] = v;
-		end
-	else
-		global[key] = value;
-	end
-
-	-- Persist to saved variables
-	if SIPPYCUP.db then
-		SIPPYCUP.db.global = SIPPYCUP.db.global or {};
-		SIPPYCUP.db.global[key] = value;
-	end
-end
-
----RefreshUI refreshes the configuration menu by updating widgets and syncing profile values.
----It only runs if the config menu frame and its refresh method are available.
+---Setup initializes the database and resolves the active profile.
 ---@return nil
-function SIPPYCUP.Database.RefreshUI()
-	if SIPPYCUP.configFrame then
-		SIPPYCUP_ConfigMenuFrame:RefreshWidgets();
-		SIPPYCUP_ConfigMenuFrame:SwitchProfileValues();
-	end
-end
+function Database:Init()
+	SippyCupDB = SippyCupDB or {
+		global = {},
+		profileKeys = {},
+		profiles = {},
+	};
 
----GetUnitName Returns the player's full name with realm if available.
----Retrieves the player's unmodified name and normalized realm.
----Returns nil if player name is invalid or realm is missing.
----@return string? fullName Full player name in "Name - Realm" format or nil if unavailable.
-function SIPPYCUP.Database.GetUnitName()
-	local playerName, realm = UnitNameUnmodified("player");
-	if not playerName or playerName == UNKNOWNOBJECT or playerName:len() == 0 then
-		return nil;
-	end
-
-	if not realm or realm:len() == 0 then
-		realm = GetRealmName();
-	end
-
-	if realm and realm:len() > 0 then
-		return playerName .. " - " .. realm;
-	end
-
-	return nil;
-end
-
----Setup initializes the database, registers callbacks, and configures options tables for the addon.
----@return nil
-function SIPPYCUP.Database.Setup()
-	local db = SIPPYCUP.db;
-
-	-- Ensure required top-level tables exist
+	local db = SippyCupDB;
 	db.global = db.global or {};
-	db.profiles = db.profiles or {};
 	db.profileKeys = db.profileKeys or {};
+	db.profiles = db.profiles or {};
 
-	-- Fill in missing global keys from defaults (preserves saved overrides)
-	DeepCopyDefaults(defaults.global, db.global);
+	PopulateDefaultProfileOptions();
+	PopulateDefaultCharOptions();
 
-	-- Use the saved table directly for runtime global
-	SIPPYCUP.global = db.global;
+	self.defaults = SIPPYCUP_UTILS.DeepCopy(DEFAULT_PROFILE);
+	self.charDefaults = SIPPYCUP_UTILS.DeepCopy(DEFAULT_CHAR);
 
-	-- Get current character identifier
-	local charKey = SIPPYCUP.Database.GetUnitName() or "Unknown";
-	local profileName = db.profileKeys[charKey] or "Default";
-	db.profileKeys[charKey] = profileName;
+	local playerKey = SIPPYCUP_UTILS.GetUnitName() or "Unknown";
+	local profileName = db.profileKeys[playerKey] or "Default";
 
-	-- Ensure the named profile exists
 	db.profiles[profileName] = db.profiles[profileName] or {};
+	self.currentProfile = db.profiles[profileName];
+	db.profileKeys[playerKey] = profileName;
 
-	-- Start from a clean copy of the default profile
-	local defaultProfile = defaults.profiles.Default or {};
-	local workingProfile = {};
-	DeepCopyDefaults(defaultProfile, workingProfile);
+	---Prune all profiles to remove values that match their defaults.
+	for _, profileData in pairs(db.profiles) do
+		pruneProfile(profileData);
+	end
 
-	-- Merge minimal saved data into working profile
-	DeepMerge(db.profiles[profileName], workingProfile);
+	self:InitCharacterDatabase();
+end
 
-	-- Save minimal differences back to saved variables
-	db.profiles[profileName] = GetMinimalTable(workingProfile, defaultProfile);
+---Initialises or migrates the character-specific chat database, clearing history on version change.
+function Database:InitCharacterDatabase()
+	SippyCupCharDB = SippyCupCharDB or {};
 
-	-- Set runtime profile
-	SIPPYCUP.Profile = workingProfile;
+	for k in pairs(SippyCupCharDB) do
+		if type(k) ~= "number" then
+			SippyCupCharDB[k] = nil;
+		end
+	end
+
+	self.currentChar = SippyCupCharDB;
 
 	SIPPYCUP.States.databaseLoaded = true;
+end
+
+---Checks whether a profile with the given name exists.
+---@param profileName string
+---@return boolean exists
+function Database:ProfileExists(profileName)
+	if not SippyCupDB or not SippyCupDB.profiles or not profileName then return false; end
+	return SippyCupDB.profiles[profileName] ~= nil;
+end
+
+---Returns the current profile table.
+---@return SippyCupProfile? currentProfile
+function Database:GetProfile()
+	return self.currentProfile;
+end
+
+---Returns the name of the current profile for the current player.
+---@return string? currentProfile
+function Database:GetProfileName()
+	if not SippyCupDB then return nil; end
+	local playerKey = SIPPYCUP_UTILS.GetUnitName() or "Unknown";
+	return SippyCupDB.profileKeys[playerKey];
 end
 
 ---GetAllProfiles returns a table of profile names keyed by name.
 ---@param excludeCurrent boolean? If true, excludes the current active profile. Defaults to false.
 ---@param excludeDefault boolean? If true, excludes the "Default" profile. Defaults to false.
 ---@return table<string, string> A table of profile names keyed by profile name.
-function SIPPYCUP.Database.GetAllProfiles(excludeCurrent, excludeDefault)
+function Database:GetAllProfiles(excludeCurrent, excludeDefault)
 	local results = {};
-	local key = SIPPYCUP.Database.GetUnitName();
-	local currentProfile = key and SIPPYCUP.db.profileKeys and SIPPYCUP.db.profileKeys[key];
+	if not SippyCupDB or not SippyCupDB.profiles then
+		return results;
+	end
 
-	local profiles = SIPPYCUP.db.profiles or {};
-	for profileName in pairs(profiles) do
-		if not ((excludeCurrent and profileName == currentProfile) or
-				(excludeDefault and profileName == "Default")) then
-			results[profileName] = profileName;
+	local currentName = self:GetProfileName();
+
+	for name in pairs(SippyCupDB.profiles) do
+		if not ((excludeCurrent and name == currentName) or
+				(excludeDefault and name == "Default")) then
+			results[name] = name;
 		end
 	end
 
 	return results;
 end
 
----GetCurrentProfileName returns the profile name associated with the current character.
----@return string? #The current profile name, or nil if not found.
-function SIPPYCUP.Database.GetCurrentProfileName()
-	if not SIPPYCUP.db or not SIPPYCUP.db.profileKeys then
-		SIPPYCUP.Database.Setup();
+---Switches to a different profile.
+---@param profileName string Name of the profile to switch to.
+---@return nil
+function Database:SetProfile(profileName)
+	if not profileName or profileName == "" then return; end
+
+	local db = SippyCupDB;
+	db.profiles[profileName] = db.profiles[profileName] or {};
+
+	self.currentProfile = db.profiles[profileName];
+
+	local playerKey = SIPPYCUP_UTILS.GetUnitName();
+	db.profileKeys[playerKey] = profileName;
+
+	SIPPYCUP.Popups.HideAllRefreshPopups();
+	SIPPYCUP.Auras.CancelAllPreExpirationTimers();
+	SIPPYCUP.Items.CancelAllItemTimers();
+	self:RebuildAuraMap();
+
+	if SIPPYCUP.configFrame then
+		SIPPYCUP_ConfigMenuFrame:RefreshWidgets();
+		SIPPYCUP_ConfigMenuFrame:SwitchProfileValues();
 	end
 
-	local key = SIPPYCUP.Database.GetUnitName();
-	return SIPPYCUP.db and SIPPYCUP.db.profileKeys and SIPPYCUP.db.profileKeys[key] or nil;
+	SIPPYCUP.Options.RefreshStackSizes(
+		SIPPYCUP.MSP.IsEnabled() and self:GetGlobalSetting("MSPStatusCheck"),
+		false, true
+	);
 end
 
----GetCurrentProfile returns the current profile name and its associated data table.
----@return string? name The profile name.
----@return table? data The resolved profile data table.
-function SIPPYCUP.Database.GetCurrentProfile()
-	if not SIPPYCUP.db or not SIPPYCUP.db.profileKeys or not SIPPYCUP.db.profiles then
-		return nil, nil;
-	end
-
-	local key = SIPPYCUP.Database.GetUnitName();
-	local profileName = SIPPYCUP.db.profileKeys[key] or "Default";
-	local minimalProfile = SIPPYCUP.db.profiles[profileName] or {};
-
-	local defaultProfile = defaults.profiles.Default or {};
-	local resolvedProfile = {};
-	DeepCopyDefaults(defaultProfile, resolvedProfile);
-	DeepMerge(minimalProfile, resolvedProfile);
-
-	return profileName, resolvedProfile;
-end
-
----ProfileExists checks whether a profile with the given name exists.
----@param profileName string The profile name to check.
----@return boolean exists True if the profile exists, false otherwise.
-function SIPPYCUP.Database.ProfileExists(profileName)
-	if not SIPPYCUP.db or not SIPPYCUP.db.profiles or not profileName then return false; end
-	return SIPPYCUP.db.profiles[profileName] ~= nil;
-end
-
----SetProfile sets the active profile for the current character (creates it if missing).
----@param profileName string The name of the profile to activate.
----@return boolean success, string? errorMessage
-function SIPPYCUP.Database.SetProfile(profileName)
-	if not SIPPYCUP.db or not SIPPYCUP.db.profiles or not profileName then
-		return false, "Database not initialized or invalid profile name";
-	end
-
-	local db = SIPPYCUP.db;
-	local defaultProfile = defaults.profiles.Default or {};
-
-	-- Persist current runtime profile before switching
-	PersistCurrentProfile();
-
-	-- Create target profile if it does not exist
-	if not db.profiles[profileName] then
-		db.profiles[profileName] = {};
-	end
-
-	-- Resolve full profile (defaults + minimal overrides)
-	local minimalProfile = db.profiles[profileName];
-	local resolvedProfile = {};
-	DeepCopyDefaults(defaultProfile, resolvedProfile);
-	DeepMerge(minimalProfile, resolvedProfile);
-
-	-- Update keys and runtime profile
-	local charKey = SIPPYCUP.Database.GetUnitName();
-	db.profileKeys = db.profileKeys or {};
-	db.profileKeys[charKey] = profileName;
-
-	-- Set runtime profile
-	SIPPYCUP.Profile = resolvedProfile;
-
-	-- Refresh UI
-	SIPPYCUP.Database.RefreshUI();
-
+---Creates a new profile and switches to it. If the profile already exists, switches to it.
+---@param profileName string
+---@return boolean success
+function Database:CreateProfile(profileName)
+	if not profileName or profileName == "" then return false; end
+	self:SetProfile(profileName);
 	return true;
 end
 
----CreateProfile creates a new profile and switches to it.
----@param profileName string The name of the new profile to create.
----@return boolean success, string? errorMessage
-function SIPPYCUP.Database.CreateProfile(profileName)
-	if not SIPPYCUP.db or not SIPPYCUP.db.profiles then
-		return false, "Database not initialized";
-	end
-	if not profileName or profileName:trim() == "" then
-		return false, "Invalid profile name";
-	end
-	if SIPPYCUP.Database.ProfileExists(profileName) then
-		return false, "A profile with that name already exists";
-	end
+---Renames an existing profile and updates all character bindings that reference it.
+---@param oldName string The current name of the profile.
+---@param newName string The desired new name.
+---@return boolean success
+function Database:RenameProfile(oldName, newName)
+	if not SippyCupDB or not SippyCupDB.profiles then return false; end
+	if not oldName or not SippyCupDB.profiles[oldName] then return false; end
+	if oldName == "Default" then return false; end
+	if not newName or newName == "" then return false; end
+	if self:ProfileExists(newName) then return false; end
 
-	local db = SIPPYCUP.db;
-	local defaultProfile = defaults.profiles.Default or {};
+	local db = SippyCupDB;
 
-	-- Persist current runtime profile before switching
-	PersistCurrentProfile();
-
-	-- Create an empty minimal profile (no overrides)
-	db.profiles[profileName] = {};
-
-	-- Assign new profile to current character
-	local key = SIPPYCUP.Database.GetUnitName();
-	db.profileKeys = db.profileKeys or {};
-	db.profileKeys[key] = profileName;
-
-	-- Set runtime profile to defaults (since minimal is empty)
-	SIPPYCUP.Profile = {};
-	DeepCopyDefaults(defaultProfile, SIPPYCUP.Profile);
-
-	SIPPYCUP.Database.RefreshUI();
-
-	return true;
-end
-
----RenameProfile renames an existing profile and updates all character bindings.
----@param oldName string The current name of the profile to rename.
----@param newName string The new name for the profile.
----@return boolean success, string? errorMessage
-function SIPPYCUP.Database.RenameProfile(oldName, newName)
-	if not SIPPYCUP.db or not SIPPYCUP.db.profiles then
-		return false, "Database not initialized";
-	end
-	if not oldName or not SIPPYCUP.db.profiles[oldName] then
-		return false, "Profile does not exist";
-	end
-	if oldName == "Default" then
-		return false, "Default profile cannot be renamed";
-	end
-	if not newName or newName:trim() == "" then
-		return false, "Invalid profile name";
-	end
-	if SIPPYCUP.Database.ProfileExists(newName) then
-		return false, "A profile with that name already exists";
-	end
-
-	local db = SIPPYCUP.db;
-
-	-- Persist current runtime profile before modifying saved data
-	PersistCurrentProfile();
-
-	-- Move minimal profile data from old key to new key
+	---Move profile data from the old key to the new key.
 	db.profiles[newName] = db.profiles[oldName];
 	db.profiles[oldName] = nil;
 
-	-- Reassign all character bindings that reference the old name
-	if db.profileKeys then
-		for charKey, profName in pairs(db.profileKeys) do
-			if profName == oldName then
-				db.profileKeys[charKey] = newName;
-			end
+	---Reassign every character binding that pointed at the old name.
+	for charKey, profName in pairs(db.profileKeys) do
+		if profName == oldName then
+			db.profileKeys[charKey] = newName;
 		end
 	end
 
-	SIPPYCUP.Database.RefreshUI();
-
-	return true;
-end
-
----ResetProfile resets the specified profile to default by clearing overrides.
----@param profileName string? The profile name to reset. Defaults to current profile.
----@return boolean success, string? errorMessage
-function SIPPYCUP.Database.ResetProfile(profileName)
-	if not SIPPYCUP.db or not SIPPYCUP.db.profiles then
-		return false, "Database not initialized";
-	end
-
-	profileName = profileName or SIPPYCUP.Database.GetCurrentProfileName();
-	if not profileName or not SIPPYCUP.db.profiles[profileName] then
-		return false, "Profile does not exist";
-	end
-
-	-- Reset profile minimal data to empty (no user overrides)
-	SIPPYCUP.db.profiles[profileName] = {};
-
-	-- If resetting current profile, update runtime resolved profile and UI
-	local currentProfileName = SIPPYCUP.Database.GetCurrentProfileName();
-	if profileName == currentProfileName then
-		local defaultProfile = defaults.profiles.Default or {};
-
-		SIPPYCUP.Profile = {};
-		DeepCopyDefaults(defaultProfile, SIPPYCUP.Profile);
-		-- No minimal overrides after reset
-
-		SIPPYCUP.Database.RefreshUI();
+	if SIPPYCUP.configFrame then
+		SIPPYCUP_ConfigMenuFrame:RefreshWidgets();
+		SIPPYCUP_ConfigMenuFrame:SwitchProfileValues();
 	end
 
 	return true;
 end
 
----CopyProfile copies settings from a source profile to the current profile.
----@param sourceProfileName string The name of the profile to copy from.
----@return boolean success, string? errorMessage
-function SIPPYCUP.Database.CopyProfile(sourceProfileName)
-	if not SIPPYCUP.db or not SIPPYCUP.db.profiles then
-		return false, "Database not initialized";
+---Creates a new profile as a copy of an existing one and switches to it.
+---@param sourceName string
+---@param newName string
+---@return boolean success
+function Database:CloneProfile(sourceName, newName)
+	if not newName or newName == "" then return false; end
+	if not SippyCupDB.profiles[sourceName] then return false; end
+
+	self:SetProfile(newName);
+	return self:CopyProfile(sourceName);
+end
+
+---Copies all settings from a source profile into the current profile, overwriting everything.
+---@param sourceName string
+---@return boolean success
+function Database:CopyProfile(sourceName)
+	local current = self.currentProfile;
+	local source = SippyCupDB.profiles[sourceName];
+	if not current or not source then return false; end
+
+	for k in pairs(current) do
+		current[k] = nil;
 	end
-	if not sourceProfileName or not SIPPYCUP.db.profiles[sourceProfileName] then
-		return false, "Source profile does not exist";
+
+	local copy = SIPPYCUP_UTILS.DeepCopy(source);
+	for k, v in pairs(copy) do
+		current[k] = v;
 	end
 
-	local currentProfileName = SIPPYCUP.Database.GetCurrentProfileName();
-	if not currentProfileName or not SIPPYCUP.db.profiles[currentProfileName] then
-		return false, "Current profile does not exist";
+	SIPPYCUP.Popups.HideAllRefreshPopups();
+	SIPPYCUP.Auras.CancelAllPreExpirationTimers();
+	SIPPYCUP.Items.CancelAllItemTimers();
+	self:RebuildAuraMap();
+
+	if SIPPYCUP.configFrame then
+		SIPPYCUP_ConfigMenuFrame:RefreshWidgets();
+		SIPPYCUP_ConfigMenuFrame:SwitchProfileValues();
 	end
-	if sourceProfileName == currentProfileName then
-		return false, "Source and current profile are the same";
-	end
 
-	local defaultProfile = defaults.profiles.Default or {};
-
-	-- Resolve full source profile data by merging saved minimal data on top of defaults
-	local sourceFull = {};
-	DeepCopyDefaults(defaultProfile, sourceFull);
-	DeepMerge(SIPPYCUP.db.profiles[sourceProfileName], sourceFull);
-
-	-- Save only minimal differences from defaults into current profile
-	local minimalCopy = GetMinimalTable(sourceFull, defaultProfile);
-	SIPPYCUP.db.profiles[currentProfileName] = minimalCopy;
-
-	-- Update runtime shortcut for current profile
-	SIPPYCUP.Profile = {};
-	DeepCopyDefaults(defaultProfile, SIPPYCUP.Profile);
-	DeepMerge(minimalCopy, SIPPYCUP.Profile);
-
-	SIPPYCUP.Database.RefreshUI();
+	SIPPYCUP.Options.RefreshStackSizes(
+		SIPPYCUP.MSP.IsEnabled() and self:GetGlobalSetting("MSPStatusCheck"),
+		false, true
+	);
 
 	return true;
 end
 
----DeleteProfile deletes a profile and reassigns characters using it to Default.
----@param profileName string The name of the profile to delete.
----@return boolean success, string? errorMessage
-function SIPPYCUP.Database.DeleteProfile(profileName)
-	if not SIPPYCUP.db or not SIPPYCUP.db.profiles then
-		return false, "Database not initialized";
-	end
-	if not profileName or not SIPPYCUP.db.profiles[profileName] then
-		return false, "Profile does not exist";
-	end
+---Deletes a profile from saved variables. Prevents deleting the active profile.
+---@param profileName string
+---@return boolean success
+function Database:DeleteProfile(profileName)
+	if not profileName or profileName == "" then return false; end
+	if profileName == self:GetProfileName() then return false; end
+	if not SippyCupDB.profiles[profileName] then return true; end
 
-	if profileName == "Default" then
-		return false, "Default profile cannot be deleted";
-	end
+	SippyCupDB.profiles[profileName] = nil;
 
-	-- Delete the profile minimal data
-	SIPPYCUP.db.profiles[profileName] = nil;
-
-	-- Check current profile via profileKeys mapping for current character
-	local charKey = SIPPYCUP.Database.GetUnitName();
-	local currentProfile = SIPPYCUP.db.profileKeys[charKey] or "Default";
-
-	-- Remove any profileKeys that point to this profile
-	if SIPPYCUP.db.profileKeys then
-		for key, profName in pairs(SIPPYCUP.db.profileKeys) do
-			if profName == profileName then
-				SIPPYCUP.db.profileKeys[key] = "Default";
-			end
+	for key, name in pairs(SippyCupDB.profileKeys) do
+		if name == profileName then
+			SippyCupDB.profileKeys[key] = "Default";
 		end
 	end
 
-	if profileName == currentProfile then
-		-- Switch character's profile to Default
-		SIPPYCUP.db.profileKeys[charKey] = "Default";
+	return true;
+end
 
-		-- Ensure Default profile exists minimally (no overrides = empty table)
-		if not SIPPYCUP.db.profiles["Default"] then
-			SIPPYCUP.db.profiles["Default"] = {};
-		end
+---Resets the current profile to default values.
+---@return boolean success
+function Database:ResetProfile()
+	local current = self.currentProfile;
+	if not current then return false; end
 
-		-- Update runtime shortcut with full Default profile data
-		SIPPYCUP.Profile = {};
-		DeepCopyDefaults(defaults.profiles.Default, SIPPYCUP.Profile);
-		DeepMerge(SIPPYCUP.db.profiles["Default"], SIPPYCUP.Profile);
+	for k in pairs(current) do
+		current[k] = nil;
+	end
 
-		SIPPYCUP.Database.RefreshUI();
+	SIPPYCUP.Popups.HideAllRefreshPopups();
+	SIPPYCUP.Auras.CancelAllPreExpirationTimers();
+	SIPPYCUP.Items.CancelAllItemTimers();
+	self:RebuildAuraMap();
+
+	if SIPPYCUP.configFrame then
+		SIPPYCUP_ConfigMenuFrame:RefreshWidgets();
+		SIPPYCUP_ConfigMenuFrame:SwitchProfileValues();
 	end
 
 	return true;
 end
+
+---@alias SippyCupProfileSettingKey
+---| "enable"
+---| "desiredStacks"
+---| "aura"
+---| "castAura"
+---| "untrackableByAura"
+---| "type"
+---| "isPrism"
+---| "instantUpdate"
+---| "usesCharges"
+
+---Returns the profile option for a given auraID, merging defaults with stored differences.
+---@param auraID number The aura ID to lookup.
+---@return SippyCupProfile option The profile option table for this aura.
+function Database:GetProfileOption(auraID)
+	local defaults = self.defaults[auraID];
+	if not defaults then return nil; end
+
+	local profile = self.currentProfile and self.currentProfile[auraID];
+	if profile then
+		return mergeTables(defaults, profile);
+	end
+
+	-- Return a shallow copy of defaults to prevent accidental mutation
+	return SIPPYCUP_UTILS.ShallowCopy(defaults);
+end
+
+---@param auraID number
+---@param key SippyCupProfileSettingKey
+---@return any
+function Database:GetAuraSetting(auraID, key)
+	local defaults = self.defaults[auraID];
+	if not defaults then return nil; end
+
+	local profile = self.currentProfile and self.currentProfile[auraID];
+	local defValue = defaults[key];
+
+	if profile and profile[key] ~= nil then
+		if type(defValue) == "table" then
+			return mergeTables(defValue, profile[key]);
+		end
+		return profile[key];
+	end
+
+	if type(defValue) == "table" then
+		return SIPPYCUP_UTILS.ShallowCopy(defValue);
+	end
+
+	return defValue;
+end
+
+---@param auraID number
+---@param key SippyCupProfileSettingKey
+---@param value any
+function Database:SetAuraSetting(auraID, key, value)
+	if not self.currentProfile then return; end
+	local defaults = self.defaults[auraID];
+	if not defaults then return; end
+
+	self.currentProfile[auraID] = self.currentProfile[auraID] or {};
+	local profileEntry = self.currentProfile[auraID];
+
+	local defValue = defaults[key];
+
+	if type(value) == "table" then
+		profileEntry[key] = pruneToDefaults(value, defValue);
+	elseif value == defValue then
+		profileEntry[key] = nil;
+	else
+		profileEntry[key] = value;
+	end
+
+	-- Remove the per-aura table entirely if all keys were pruned to defaults
+	if not next(profileEntry) then
+		self.currentProfile[auraID] = nil;
+	end
+
+	if SIPPYCUP.configFrame then
+		SIPPYCUP_ConfigMenuFrame:RefreshWidgets();
+		SIPPYCUP_ConfigMenuFrame:SwitchProfileValues();
+	end
+end
+
+---@alias SippyCupCharSettingKey
+---| "currentInstanceID"
+---| "currentStacks"
+---| "currentItemID"
+---| "lastItemCount"
+
+---Returns the character settings for a given auraID, merging defaults with stored differences.
+---@param auraID number The aura ID to lookup.
+---@return SippyCupCharSettings charSettings
+function Database:GetCharSettings(auraID)
+	local defaults = self.charDefaults[auraID];
+	if not defaults then return nil; end
+
+	local charSettings = self.currentChar and self.currentChar[auraID];
+	if charSettings then
+		return mergeTables(defaults, charSettings);
+	end
+
+	-- Return a shallow copy of defaults to prevent accidental mutation
+	return SIPPYCUP_UTILS.ShallowCopy(defaults);
+end
+
+---Returns a single value from the character settings for a given auraID.
+---@param auraID number
+---@param key SippyCupCharSettingKey
+---@return any
+function Database:GetCharSetting(auraID, key)
+	local charSettings = self:GetCharSettings(auraID);
+	if not charSettings then return nil; end
+	return charSettings[key];
+end
+
+---Stores a character setting for a given auraID, pruning values equal to their defaults.
+---@param auraID number
+---@param key SippyCupCharSettingKey
+---@param value any
+function Database:SetCharSetting(auraID, key, value)
+	if type(auraID) ~= "number" then return; end  -- ignore non-numeric keys
+
+	if not SippyCupCharDB then SippyCupCharDB = {}; end
+	self.currentChar = self.currentChar or SippyCupCharDB;
+
+	local defaults = self.charDefaults[auraID] or {};
+	self.currentChar[auraID] = self.currentChar[auraID] or SIPPYCUP_UTILS.DeepCopy(defaults);
+
+	if type(value) == "table" then
+		self.currentChar[auraID][key] = pruneToDefaults(value, defaults[key]);
+	elseif value == defaults[key] then
+		self.currentChar[auraID][key] = nil;
+	else
+		self.currentChar[auraID][key] = value;
+	end
+
+	-- Remove the per-aura table entirely if all keys were pruned to defaults
+	if not next(self.currentChar[auraID]) then
+		self.currentChar[auraID] = nil;
+	end
+end
+
+---@alias SippyCupGlobalSettingKey
+---| "AlertSound"
+---| "AlertSoundID"
+---| "DebugOutput"
+---| "FlashTaskbar"
+---| "Flyway"
+---| "InsufficientReminder"
+---| "MinimapButton"
+---| "MSPStatusCheck"
+---| "NewFeatureNotification"
+---| "PopupPosition"
+---| "PreExpirationChecks"
+---| "PreExpirationLeadTimer"
+---| "ProjectionPrismPreExpirationLeadTimer"
+---| "ReflectingPrismPreExpirationLeadTimer"
+---| "UseToyCooldown"
+---| "WelcomeMessage"
+
+---Returns a global setting, merging defaults with stored values for tables.
+---@param key SippyCupGlobalSettingKey
+---@return any
+function Database:GetGlobalSetting(key)
+	if not SippyCupDB then SippyCupDB = {}; end
+	if not SippyCupDB.global then SippyCupDB.global = {}; end
+
+	local stored = SippyCupDB.global[key];
+	local def = self.globalDefaults[key];
+
+	if type(def) == "table" then
+		if stored then
+			return mergeTables(def, stored);
+		else
+			-- Initialize stored table with shallow copy to keep live reference
+			local init = SIPPYCUP_UTILS.ShallowCopy(def);
+			SippyCupDB.global[key] = init;
+			return init;
+		end
+	end
+
+	-- Return primitive or nil
+	if stored ~= nil then return stored; end
+	return def;
+end
+
+---Stores a global setting. Table values are merged into the existing stored table in place,
+---preserving keys written by LibDBIcon (e.g. minimapPos) that are not part of our defaults.
+---@param key SippyCupGlobalSettingKey
+---@param value any
+function Database:SetGlobalSetting(key, value)
+	if not SippyCupDB then SippyCupDB = {}; end
+	if not SippyCupDB.global then SippyCupDB.global = {}; end
+
+	local def = self.globalDefaults[key];
+
+	if type(value) == "table" then
+		-- Merge into the existing table to preserve LibDBIcon-managed keys.
+		SippyCupDB.global[key] = SippyCupDB.global[key] or {};
+		for k, v in pairs(value) do
+			SippyCupDB.global[key][k] = v;
+		end
+	elseif value == def then
+		SippyCupDB.global[key] = nil;
+	else
+		SippyCupDB.global[key] = value;
+	end
+
+	if SIPPYCUP.configFrame then
+		SIPPYCUP_ConfigMenuFrame:RefreshWidgets();
+		SIPPYCUP_ConfigMenuFrame:SwitchProfileValues();
+	end
+end
+
+SIPPYCUP.Database = Database;

--- a/Core/Database.lua
+++ b/Core/Database.lua
@@ -404,6 +404,24 @@ function Database:InitCharacterDatabase()
 	SIPPYCUP.States.databaseLoaded = true;
 end
 
+---Refreshes the config UI if the configuration frame is loaded.
+---@return nil
+function Database:refreshUI()
+	if SIPPYCUP.configFrame then
+		SIPPYCUP_ConfigMenuFrame:RefreshWidgets();
+		SIPPYCUP_ConfigMenuFrame:SwitchProfileValues();
+	end
+end
+
+---applyProfileSwitch resets runtime systems after a profile change.
+---@return nil
+function Database:applyProfileSwitch()
+	SIPPYCUP.Popups.HideAllRefreshPopups();
+	SIPPYCUP.Auras.CancelAllPreExpirationTimers();
+	SIPPYCUP.Items.CancelAllItemTimers();
+	self:RebuildAuraMap();
+end
+
 ---Checks whether a profile with the given name exists.
 ---@param profileName string
 ---@return boolean exists
@@ -462,15 +480,8 @@ function Database:SetProfile(profileName)
 	local playerKey = SIPPYCUP_UTILS.GetUnitName();
 	db.profileKeys[playerKey] = profileName;
 
-	SIPPYCUP.Popups.HideAllRefreshPopups();
-	SIPPYCUP.Auras.CancelAllPreExpirationTimers();
-	SIPPYCUP.Items.CancelAllItemTimers();
-	self:RebuildAuraMap();
-
-	if SIPPYCUP.configFrame then
-		SIPPYCUP_ConfigMenuFrame:RefreshWidgets();
-		SIPPYCUP_ConfigMenuFrame:SwitchProfileValues();
-	end
+	self:applyProfileSwitch();
+	self:refreshUI();
 
 	SIPPYCUP.Options.RefreshStackSizes(
 		SIPPYCUP.MSP.IsEnabled() and self:GetGlobalSetting("MSPStatusCheck"),
@@ -511,10 +522,7 @@ function Database:RenameProfile(oldName, newName)
 		end
 	end
 
-	if SIPPYCUP.configFrame then
-		SIPPYCUP_ConfigMenuFrame:RefreshWidgets();
-		SIPPYCUP_ConfigMenuFrame:SwitchProfileValues();
-	end
+	self:refreshUI();
 
 	return true;
 end
@@ -548,15 +556,8 @@ function Database:CopyProfile(sourceName)
 		current[k] = v;
 	end
 
-	SIPPYCUP.Popups.HideAllRefreshPopups();
-	SIPPYCUP.Auras.CancelAllPreExpirationTimers();
-	SIPPYCUP.Items.CancelAllItemTimers();
-	self:RebuildAuraMap();
-
-	if SIPPYCUP.configFrame then
-		SIPPYCUP_ConfigMenuFrame:RefreshWidgets();
-		SIPPYCUP_ConfigMenuFrame:SwitchProfileValues();
-	end
+	self:applyProfileSwitch();
+	self:refreshUI();
 
 	SIPPYCUP.Options.RefreshStackSizes(
 		SIPPYCUP.MSP.IsEnabled() and self:GetGlobalSetting("MSPStatusCheck"),
@@ -595,15 +596,8 @@ function Database:ResetProfile()
 		current[k] = nil;
 	end
 
-	SIPPYCUP.Popups.HideAllRefreshPopups();
-	SIPPYCUP.Auras.CancelAllPreExpirationTimers();
-	SIPPYCUP.Items.CancelAllItemTimers();
-	self:RebuildAuraMap();
-
-	if SIPPYCUP.configFrame then
-		SIPPYCUP_ConfigMenuFrame:RefreshWidgets();
-		SIPPYCUP_ConfigMenuFrame:SwitchProfileValues();
-	end
+	self:applyProfileSwitch();
+	self:refreshUI();
 
 	return true;
 end
@@ -685,10 +679,7 @@ function Database:SetAuraSetting(auraID, key, value)
 		self.currentProfile[auraID] = nil;
 	end
 
-	if SIPPYCUP.configFrame then
-		SIPPYCUP_ConfigMenuFrame:RefreshWidgets();
-		SIPPYCUP_ConfigMenuFrame:SwitchProfileValues();
-	end
+	self:refreshUI();
 end
 
 ---@alias SippyCupCharSettingKey
@@ -816,10 +807,7 @@ function Database:SetGlobalSetting(key, value)
 		SippyCupDB.global[key] = value;
 	end
 
-	if SIPPYCUP.configFrame then
-		SIPPYCUP_ConfigMenuFrame:RefreshWidgets();
-		SIPPYCUP_ConfigMenuFrame:SwitchProfileValues();
-	end
+	self:refreshUI();
 end
 
 SIPPYCUP.Database = Database;

--- a/Core/Database.lua
+++ b/Core/Database.lua
@@ -741,6 +741,29 @@ function Database:SetCharSetting(auraID, key, value)
 	end
 end
 
+---Returns a merged copy of both profile and character settings for a given aura ID.
+---Combines defaults with stored overrides from the active profile and character database.
+---@param auraID number The aura ID to look up.
+---@return SippyCupProfile? option The fully merged option, or nil if no defaults exist.
+function Database:GetOption(auraID)
+	local profileDefaults = self.defaults[auraID];
+	if not profileDefaults then return nil; end
+
+	local profileOverride = self.currentProfile and self.currentProfile[auraID];
+	local result = mergeTables(profileDefaults, profileOverride or {});
+
+	local charDefaults = self.charDefaults[auraID];
+	if charDefaults then
+		local charOverride = self.currentChar and self.currentChar[auraID];
+		local charMerged = mergeTables(charDefaults, charOverride or {});
+		for k, v in pairs(charMerged) do
+			result[k] = v;
+		end
+	end
+
+	return result;
+end
+
 ---@alias SippyCupGlobalSettingKey
 ---| "AlertSound"
 ---| "AlertSoundID"

--- a/Core/Database.lua
+++ b/Core/Database.lua
@@ -234,6 +234,16 @@ function Database:RebuildAuraMap()
 			local castAuraID = profileOptionData.castAura or auraID;
 			self.castAuraToProfile[castAuraID] = profileOptionData;
 
+			-- Apply stored character data so fields like currentItemID and lastItemCount persist after reload.
+			-- currentInstanceID and currentStacks will be refreshed by the live checks below.
+			local charData = self.currentChar and self.currentChar[auraID];
+			if charData then
+				for k, v in pairs(charData) do
+					profileOptionData[k] = v;
+				end
+			end
+
+			-- Overwrite instance/stacks with fresh live aura data.
 			local auraInfo;
 			if profileOptionData.currentInstanceID then
 				auraInfo = GetAuraDataByAuraInstanceID("player", profileOptionData.currentInstanceID);
@@ -247,21 +257,38 @@ function Database:RebuildAuraMap()
 				auraInfo, auraID, SIPPYCUP.Popups.Reason.STARTUP, auraInfo ~= nil
 			);
 
-			-- persist to character DB
-			self:SetCharSetting(auraID, "currentInstanceID", profileOptionData.currentInstanceID);
-			self:SetCharSetting(auraID, "currentStacks", profileOptionData.currentStacks);
-
 			if profileOptionData.currentInstanceID then
 				self.instanceToProfile[profileOptionData.currentInstanceID] = profileOptionData;
 			end
 
 			-- Handle options that are trackable without auras (via itemID)
-			if profileOptionData.untrackableByAura then
-				local optionData = SIPPYCUP.Options.ByAuraID[auraID];
-				if optionData and optionData.itemID then
-					self.untrackableByAuraProfile[optionData.itemID] = profileOptionData;
+			local optionData = SIPPYCUP.Options.ByAuraID[auraID];
+
+			-- Resolve currentItemID and lastItemCount from live inventory/toy state.
+			if optionData and optionData.itemID then
+				local isToy = SIPPYCUP.Options.Type and (optionData.type == SIPPYCUP.Options.Type.TOY);
+				local itemIDs = type(optionData.itemID) == "table" and optionData.itemID or { optionData.itemID };
+				local usableItemID;
+				local itemCount = 0;
+
+				for _, id in ipairs(itemIDs) do
+					local count = isToy and (PlayerHasToy(id) and 1 or 0) or C_Item.GetItemCount(id);
+					if count > 0 then
+						usableItemID = usableItemID or id;
+						itemCount = itemCount + count;
+					end
 				end
+
+				profileOptionData.currentItemID = usableItemID or itemIDs[#itemIDs];
+				profileOptionData.lastItemCount = itemCount;
 			end
+
+			-- Track options that rely on items instead of auras.
+			if profileOptionData.untrackableByAura and optionData and optionData.itemID then
+				self.untrackableByAuraProfile[optionData.itemID] = profileOptionData;
+			end
+
+			self:CommitCharState(auraID, profileOptionData);
 		end
 	end
 
@@ -279,31 +306,45 @@ end
 ---@param profileOptionData SippyCupProfile The profile data to update.
 ---@param enabled boolean Whether the option is enabled or disabled.
 function Database:UpdateAuraMapForOption(profileOptionData, enabled)
-	if not profileOptionData or not profileOptionData.aura then return; end
+	if not profileOptionData or not profileOptionData.aura then return; end;
 
 	local auraID = profileOptionData.aura;
 	local castAuraID = profileOptionData.castAura or auraID;
 	local optionData = SIPPYCUP.Options.ByAuraID[auraID];
 
 	if enabled then
-		-- Add/update auraToProfile and castAuraToProfile
 		self.auraToProfile[auraID] = profileOptionData;
 		self.castAuraToProfile[castAuraID] = profileOptionData;
 
-		-- Update instanceToProfile if aura is currently active
 		local auraInfo = C_UnitAuras.GetPlayerAuraBySpellID(auraID);
 		local instanceID = auraInfo and auraInfo.auraInstanceID;
+
 		profileOptionData.currentInstanceID = instanceID;
 		profileOptionData.currentStacks = SIPPYCUP.Auras.CalculateCurrentStacks(
 			auraInfo, auraID, SIPPYCUP.Popups.Reason.STARTUP, auraInfo ~= nil
 		);
 
-		-- persist to character DB
-		self:SetCharSetting(auraID, "currentInstanceID", profileOptionData.currentInstanceID);
-		self:SetCharSetting(auraID, "currentStacks", profileOptionData.currentStacks);
-
 		if instanceID then
 			self.instanceToProfile[instanceID] = profileOptionData;
+		end
+
+		-- Resolve currentItemID and lastItemCount from the current inventory/toy state.
+		if optionData and optionData.itemID then
+			local isToy = SIPPYCUP.Options.Type and (optionData.type == SIPPYCUP.Options.Type.TOY);
+			local itemIDs = type(optionData.itemID) == "table" and optionData.itemID or { optionData.itemID };
+			local usableItemID;
+			local itemCount = 0;
+
+			for _, id in ipairs(itemIDs) do
+				local count = isToy and (PlayerHasToy(id) and 1 or 0) or C_Item.GetItemCount(id);
+				if count > 0 then
+					usableItemID = usableItemID or id;
+					itemCount = itemCount + count;
+				end
+			end
+
+			profileOptionData.currentItemID = usableItemID or itemIDs[#itemIDs];
+			profileOptionData.lastItemCount = itemCount;
 		end
 
 		-- Map itemID for options trackable without an aura
@@ -311,25 +352,26 @@ function Database:UpdateAuraMapForOption(profileOptionData, enabled)
 			self.untrackableByAuraProfile[optionData.itemID] = profileOptionData;
 		end
 	else
-		-- Remove from all lookup tables
 		self.auraToProfile[auraID] = nil;
 		self.castAuraToProfile[castAuraID] = nil;
 
 		local instanceID = profileOptionData.currentInstanceID;
 		if instanceID then
 			self.instanceToProfile[instanceID] = nil;
-			profileOptionData.currentInstanceID = nil;
 		end
 
+		-- Reset char state; CommitCharState will prune unused values from the char DB.
+		profileOptionData.currentInstanceID = nil;
 		profileOptionData.currentStacks = 0;
-		-- persist to character DB
-		self:SetCharSetting(auraID, "currentInstanceID", nil);
-		self:SetCharSetting(auraID, "currentStacks", 0);
+		profileOptionData.currentItemID = nil;
+		profileOptionData.lastItemCount = 0;
 
 		if profileOptionData.untrackableByAura and optionData and optionData.itemID then
 			self.untrackableByAuraProfile[optionData.itemID] = nil;
 		end
 	end
+
+	self:CommitCharState(auraID, profileOptionData);
 end
 
 ---Returns profile data matching spell ID, aura instance ID, or item ID.
@@ -386,6 +428,7 @@ function Database:Init()
 	end
 
 	self:InitCharacterDatabase();
+	SIPPYCUP.States.databaseLoaded = true;
 end
 
 ---Initialises or migrates the character-specific chat database, clearing history on version change.
@@ -393,15 +436,31 @@ end
 function Database:InitCharacterDatabase()
 	SippyCupCharDB = SippyCupCharDB or {};
 
-	for k in pairs(SippyCupCharDB) do
-		if type(k) ~= "number" then
-			SippyCupCharDB[k] = nil;
+	self.currentChar = SippyCupCharDB;
+	self:LoadFromSaved();
+end
+
+---Normalises SippyCupCharDB against charDefaults before the first RebuildAuraMap.
+---Removes orphaned aura entries and unknown keys within entries.
+---Missing keys are left untouched; GetCharSetting falls back to defaults.
+---@return nil
+function Database:LoadFromSaved()
+	if not self.currentChar then return; end;
+
+	for auraID, charData in pairs(self.currentChar) do
+		local defaults = self.charDefaults[auraID];
+		if type(auraID) ~= "number" or not defaults then
+			-- Orphaned or non-numeric entry; prune entirely.
+			self.currentChar[auraID] = nil;
+		else
+			-- Strip keys not present in charDefaults.
+			for k in pairs(charData) do
+				if defaults[k] == nil then
+					charData[k] = nil;
+				end
+			end
 		end
 	end
-
-	self.currentChar = SippyCupCharDB;
-
-	SIPPYCUP.States.databaseLoaded = true;
 end
 
 ---Refreshes the config UI if the configuration frame is loaded.
@@ -719,7 +778,7 @@ end
 ---@param key SippyCupCharSettingKey
 ---@param value any
 function Database:SetCharSetting(auraID, key, value)
-	if type(auraID) ~= "number" then return; end  -- ignore non-numeric keys
+	if type(auraID) ~= "number" then return; end -- ignore non-numeric keys
 
 	if not SippyCupCharDB then SippyCupCharDB = {}; end
 	self.currentChar = self.currentChar or SippyCupCharDB;
@@ -741,10 +800,62 @@ function Database:SetCharSetting(auraID, key, value)
 	end
 end
 
----Returns a merged copy of both profile and character settings for a given aura ID.
----Combines defaults with stored overrides from the active profile and character database.
+---Commits all four character-specific runtime fields from a profileOptionData working
+---copy into SippyCupCharDB via SetCharSetting in a single atomic call.
+---@param auraID number
+---@param profileOptionData SippyCupProfile
+function Database:CommitCharState(auraID, profileOptionData)
+	self:SetCharSetting(auraID, "currentInstanceID", profileOptionData.currentInstanceID);
+	self:SetCharSetting(auraID, "currentStacks", profileOptionData.currentStacks);
+	self:SetCharSetting(auraID, "currentItemID", profileOptionData.currentItemID);
+	self:SetCharSetting(auraID, "lastItemCount", profileOptionData.lastItemCount);
+end
+
+---Commits a profileOptionData working copy into both the live aura lookup tables and
+---SippyCupCharDB. Use only on the fallback path where profileOptionData is a temporary
+---GetOption copy and not the live auraToProfile reference.
+---Does not perform live aura queries; trusts the values already set on profileOptionData.
+---@param auraID number
+---@param profileOptionData SippyCupProfile
+function Database:CommitFullState(auraID, profileOptionData)
+	if not profileOptionData then return; end;
+
+	local castAuraID = profileOptionData.castAura or auraID;
+	local optionData = SIPPYCUP.Options.ByAuraID[auraID];
+
+	if profileOptionData.enable then
+		self.auraToProfile[auraID] = profileOptionData;
+		self.castAuraToProfile[castAuraID] = profileOptionData;
+
+		local instanceID = profileOptionData.currentInstanceID;
+		if instanceID then
+			self.instanceToProfile[instanceID] = profileOptionData;
+		end
+
+		if profileOptionData.untrackableByAura and optionData and optionData.itemID then
+			self.untrackableByAuraProfile[optionData.itemID] = profileOptionData;
+		end
+	else
+		self.auraToProfile[auraID] = nil;
+		self.castAuraToProfile[castAuraID] = nil;
+
+		local instanceID = profileOptionData.currentInstanceID;
+		if instanceID then
+			self.instanceToProfile[instanceID] = nil;
+		end
+
+		if profileOptionData.untrackableByAura and optionData and optionData.itemID then
+			self.untrackableByAuraProfile[optionData.itemID] = nil;
+		end
+	end
+
+	self:CommitCharState(auraID, profileOptionData);
+end
+
+---Defaults are layered with the active profile and char DB overrides.
+---The returned table is a copy; changes are not applied automatically.
 ---@param auraID number The aura ID to look up.
----@return SippyCupProfile? option The fully merged option, or nil if no defaults exist.
+---@return SippyCupProfile? option The merged option, or nil if no defaults exist.
 function Database:GetOption(auraID)
 	local profileDefaults = self.defaults[auraID];
 	if not profileDefaults then return nil; end

--- a/Core/Database.lua
+++ b/Core/Database.lua
@@ -464,12 +464,13 @@ function Database:LoadFromSaved()
 end
 
 ---Re-resolves and re-points currentProfile based on the current player key.
+---@param playerKey string? Optional pre-resolved player key.
 ---@return nil
-function Database:ResolveActiveProfile()
+function Database:ResolveActiveProfile(playerKey)
 	local db = SippyCupDB;
 	if not db then return; end;
 
-	local playerKey = SIPPYCUP_UTILS.GetUnitName() or "Unknown";
+	playerKey = playerKey or SIPPYCUP_UTILS.GetUnitName() or "Unknown";
 	local profileName = db.profileKeys[playerKey] or "Default";
 
 	db.profiles[profileName] = db.profiles[profileName] or {};

--- a/Core/Database.lua
+++ b/Core/Database.lua
@@ -68,7 +68,7 @@ local GLOBAL_DEFAULTS = {
 };
 
 ---Represents a single option's tracking settings within a user profile.
----@class SippyCupProfile
+---@class SippyCupProfileSettings
 ---@field enable boolean Whether the option is enabled for tracking.
 ---@field desiredStacks integer Number of stacks the user wants to maintain.
 ---@field aura number The associated aura ID for this option.
@@ -80,7 +80,7 @@ local GLOBAL_DEFAULTS = {
 ---@field usesCharges boolean? Whether this option uses charges (generally reflecting prism).
 
 ---Default profile options keyed by aura ID
----@type table<number, SippyCupProfile>
+---@type table<number, SippyCupProfileSettings>
 local DEFAULT_PROFILE = {};
 
 ---Populate the default option's table keyed by aura ID, with all known entries from SIPPYCUP.Options.Data.
@@ -125,6 +125,8 @@ end
 ---@type table<number, SippyCupCharSettings>
 local DEFAULT_CHAR = {};
 
+---Initializes DEFAULT_CHAR entries for all aura-based options.
+---@return nil
 local function PopulateDefaultCharOptions()
 	local optionsData = SIPPYCUP.Options.Data;
 	for i = 1, #optionsData do
@@ -143,13 +145,15 @@ local function PopulateDefaultCharOptions()
 	end
 end
 
+---@class SippyCupProfile : SippyCupProfileSettings, SippyCupCharSettings
+
 Database.currentProfile = nil;
 Database.globalDefaults = SIPPYCUP_UTILS.DeepCopy(GLOBAL_DEFAULTS);
 
 ---Returns a new table containing all keys from `base`, with keys from `override` applied on top.
 ---@param base table
 ---@param override table
----@return table
+---@return SippyCupProfile
 local function mergeTables(base, override)
 	-- start with defaults
 	local result = SIPPYCUP_UTILS.ShallowCopy(base);
@@ -272,7 +276,7 @@ function Database:RebuildAuraMap()
 end
 
 ---UpdateAuraMapForOption updates or removes a profile option from aura/instance/item lookup tables.
----@param profileOptionData SippyCupCharSettings The profile data to update.
+---@param profileOptionData SippyCupProfile The profile data to update.
 ---@param enabled boolean Whether the option is enabled or disabled.
 function Database:UpdateAuraMapForOption(profileOptionData, enabled)
 	if not profileOptionData or not profileOptionData.aura then return; end
@@ -332,7 +336,7 @@ end
 ---@param spellId number? Spell ID to match `auraToProfile`.
 ---@param instanceID number? Aura instance ID to match `instanceToProfile`.
 ---@param itemID number? Item ID to match `untrackableByAuraProfile`.
----@return SippyCupCharSettings? profileOptionData
+---@return SippyCupProfile? profileOptionData
 function Database:FindMatchingProfile(spellId, instanceID, itemID)
 	if canaccessvalue == nil or canaccessvalue(spellId) then
 		if spellId ~= nil then
@@ -385,6 +389,7 @@ function Database:Init()
 end
 
 ---Initialises or migrates the character-specific chat database, clearing history on version change.
+---@return nil
 function Database:InitCharacterDatabase()
 	SippyCupCharDB = SippyCupCharDB or {};
 
@@ -408,13 +413,13 @@ function Database:ProfileExists(profileName)
 end
 
 ---Returns the current profile table.
----@return SippyCupProfile? currentProfile
+---@return SippyCupProfile currentProfile
 function Database:GetProfile()
 	return self.currentProfile;
 end
 
 ---Returns the name of the current profile for the current player.
----@return string? currentProfile
+---@return string currentProfile
 function Database:GetProfileName()
 	if not SippyCupDB then return nil; end
 	local playerKey = SIPPYCUP_UTILS.GetUnitName() or "Unknown";
@@ -495,11 +500,11 @@ function Database:RenameProfile(oldName, newName)
 
 	local db = SippyCupDB;
 
-	---Move profile data from the old key to the new key.
+	-- Move profile data from the old key to the new key.
 	db.profiles[newName] = db.profiles[oldName];
 	db.profiles[oldName] = nil;
 
-	---Reassign every character binding that pointed at the old name.
+	-- Reassign every character binding that pointed at the old name.
 	for charKey, profName in pairs(db.profileKeys) do
 		if profName == oldName then
 			db.profileKeys[charKey] = newName;

--- a/Core/Database.lua
+++ b/Core/Database.lua
@@ -615,8 +615,8 @@ end
 
 ---Returns the profile option for a given auraID, merging defaults with stored differences.
 ---@param auraID number The aura ID to lookup.
----@return SippyCupProfile option The profile option table for this aura.
-function Database:GetProfileOption(auraID)
+---@return SippyCupProfileSettings option The profile option table for this aura.
+function Database:GetProfileSettings(auraID)
 	local defaults = self.defaults[auraID];
 	if not defaults then return nil; end
 
@@ -632,7 +632,7 @@ end
 ---@param auraID number
 ---@param key SippyCupProfileSettingKey
 ---@return any
-function Database:GetAuraSetting(auraID, key)
+function Database:GetProfileSetting(auraID, key)
 	local defaults = self.defaults[auraID];
 	if not defaults then return nil; end
 
@@ -656,7 +656,7 @@ end
 ---@param auraID number
 ---@param key SippyCupProfileSettingKey
 ---@param value any
-function Database:SetAuraSetting(auraID, key, value)
+function Database:SetProfileSetting(auraID, key, value)
 	if not self.currentProfile then return; end
 	local defaults = self.defaults[auraID];
 	if not defaults then return; end

--- a/Core/Items.lua
+++ b/Core/Items.lua
@@ -214,7 +214,7 @@ function SIPPYCUP.Items.CheckNoAuraSingleOption(profileOptionData, spellID, minS
 	-- This is a reliable check, but toys might not immediately report a cooldown. But their usage generally means we can close their popup.
 	if startTime and startTime > 0 or optionData.type == SIPPYCUP.Options.Type.TOY then
 		profileOptionData.currentStacks = 1;
-		SIPPYCUP.Database:SetCharSetting(profileOptionData.aura, "currentStacks", profileOptionData.currentStacks);
+		SIPPYCUP.Database:CommitCharState(profileOptionData.aura, profileOptionData);
 		SIPPYCUP.Database.untrackableByAuraProfile[optionData.itemID] = profileOptionData;
 
 		if existingPopup and existingPopup:IsShown() then

--- a/Core/Items.lua
+++ b/Core/Items.lua
@@ -140,7 +140,7 @@ function SIPPYCUP.Items.CheckNoAuraItemUsage(minSeconds)
 end
 
 ---CheckNoAuraSingleOption evaluates cooldowns for non-aura items/toys to fire pre-expiration and removal popups.
----@param profileOptionData table? Optional profile data; will be resolved if nil.
+---@param profileOptionData SippyCupProfile? Optional profile data; will be resolved if nil.
 ---@param spellID number The spell ID to track.
 ---@param minSeconds number? Time window to check ahead, defaults to 180.
 ---@param startTime number? Optional cooldown start time.

--- a/Core/Items.lua
+++ b/Core/Items.lua
@@ -155,7 +155,7 @@ function SIPPYCUP.Items.CheckNoAuraSingleOption(profileOptionData, spellID, minS
 	end
 
 	if not profileOptionData then
-		profileOptionData = SIPPYCUP.Database.FindMatchingProfile(spellID);
+		profileOptionData = SIPPYCUP.Database:FindMatchingProfile(spellID);
 	end
 
 	-- Sanity check: if profileOptionData is nil or is not a no aura, bail out
@@ -189,7 +189,7 @@ function SIPPYCUP.Items.CheckNoAuraSingleOption(profileOptionData, spellID, minS
 		end
 
 		if optionData.spellTrackable then
-			if SIPPYCUP.global.UseToyCooldown then
+			if SIPPYCUP.Database:GetGlobalSetting("UseToyCooldown") then
 				trackByItem = true;
 			else
 				trackBySpell = true;
@@ -214,6 +214,7 @@ function SIPPYCUP.Items.CheckNoAuraSingleOption(profileOptionData, spellID, minS
 	-- This is a reliable check, but toys might not immediately report a cooldown. But their usage generally means we can close their popup.
 	if startTime and startTime > 0 or optionData.type == SIPPYCUP.Options.Type.TOY then
 		profileOptionData.currentStacks = 1;
+		SIPPYCUP.Database:SetCharSetting(profileOptionData.aura, "currentStacks", profileOptionData.currentStacks);
 		SIPPYCUP.Database.untrackableByAuraProfile[optionData.itemID] = profileOptionData;
 
 		if existingPopup and existingPopup:IsShown() then
@@ -222,11 +223,11 @@ function SIPPYCUP.Items.CheckNoAuraSingleOption(profileOptionData, spellID, minS
 	end
 
 	-- If pre-expiration checks are not on, or pre-expiration is not a thing for this item, return false.
-	if not SIPPYCUP.global.PreExpirationChecks or not optionData.preExpiration then
+	if not SIPPYCUP.Database:GetGlobalSetting("PreExpirationChecks") or not optionData.preExpiration then
 		return preExpireFired;
 	end
 
-	local preOffset = SIPPYCUP.global.PreExpirationLeadTimer * 60;
+	local preOffset = SIPPYCUP.Database:GetGlobalSetting("PreExpirationLeadTimer") * 60;
 	-- Calculate how many seconds are left on cooldown right now.
 	local expirationTime = (startTime or 0) + (duration or 0);
 	local remaining = math.max(0, expirationTime - now);

--- a/Core/Options.lua
+++ b/Core/Options.lua
@@ -272,7 +272,7 @@ function SIPPYCUP.Options.ResolveTrackingMethod(optionData)
 			return false, true;
 		end
 		if optionData.spellTrackable then
-			if SIPPYCUP.global.UseToyCooldown then
+			if SIPPYCUP.Database:GetGlobalSetting("UseToyCooldown") then
 				return false, true;
 			else
 				return true, false;
@@ -422,7 +422,7 @@ function SIPPYCUP.Options.RefreshStackSizes(checkAll, reset, preExpireOnly)
 	end
 
 	-- Rebuild the aura map from the latest database data that we have.
-	SIPPYCUP.Database.RebuildAuraMap();
+	SIPPYCUP.Database:RebuildAuraMap();
 
 	local GetPlayerAuraBySpellID = C_UnitAuras.GetPlayerAuraBySpellID;
 	local auraToProfile = SIPPYCUP.Database.auraToProfile;

--- a/Core/Utils.lua
+++ b/Core/Utils.lua
@@ -69,7 +69,7 @@ function SIPPYCUP_BUILDINFO.Output(colorized)
 end
 
 function SIPPYCUP_BUILDINFO.CheckNewlyAdded(buildAdded)
-	if not SIPPYCUP.global.NewFeatureNotification then
+	if not SIPPYCUP.Database:GetGlobalSetting("NewFeatureNotification") then
 		return;
 	end
 
@@ -154,7 +154,7 @@ end
 ---Accepts any number of arguments and joins them with space.
 ---@param ... any Values to print (strings, numbers, tables, etc.)
 function SIPPYCUP_OUTPUT.Debug(...)
-	if not SIPPYCUP.IS_DEV_BUILD or not SIPPYCUP.Database.GetGlobalSetting("DebugOutput") then return; end
+	if not SIPPYCUP.IS_DEV_BUILD or not SIPPYCUP.Database:GetGlobalSetting("DebugOutput") then return; end
 
 	local args = {...};
 	local outputLines = {};
@@ -182,4 +182,51 @@ function SIPPYCUP_TEXT.Normalize(str)
 		:gsub("Ó", "O"):gsub("Ò", "O"):gsub("Õ", "O"):gsub("Ö", "O"):gsub("Ô", "O")
 		:gsub("Ú", "U"):gsub("Ù", "U"):gsub("Û", "U"):gsub("Ü", "U")
 		:gsub("Ç", "C"):gsub("Ñ", "N");
+end
+
+SIPPYCUP_UTILS = {};
+
+---Returns a new table with all top-level key-value pairs copied from tbl.
+---@param tbl table
+---@return table
+function SIPPYCUP_UTILS.ShallowCopy(tbl)
+	local copy = {};
+	for k, v in pairs(tbl) do
+		copy[k] = v;
+	end
+	return copy;
+end
+
+---Returns a fully independent recursive copy of tbl, or the value itself if not a table.
+---@param tbl any
+---@return any
+function SIPPYCUP_UTILS.DeepCopy(tbl)
+	if type(tbl) ~= "table" then return tbl; end
+	local copy = {};
+	for k, v in pairs(tbl) do
+		copy[k] = SIPPYCUP_UTILS.DeepCopy(v);
+	end
+	return copy;
+end
+
+---GetUnitName Returns the player's full name with realm if available.
+---Retrieves the player's unmodified name and normalized realm.
+---Returns nil if player name is invalid or realm is missing.
+---@return string? fullName Full player name in "Name - Realm" format or nil if unavailable.
+function SIPPYCUP_UTILS.GetUnitName()
+	local playerName, realm = UnitNameUnmodified("player");
+
+	if not canaccessvalue(playerName) or not playerName or playerName == UNKNOWNOBJECT or playerName:len() == 0 then
+		return nil;
+	end
+
+	if not realm or realm:len() == 0 then
+		realm = GetNormalizedRealmName();
+	end
+
+	if realm and realm:len() > 0 then
+		return playerName .. "-" .. realm;
+	end
+
+	return nil;
 end

--- a/Init.lua
+++ b/Init.lua
@@ -47,6 +47,7 @@ SIPPYCUP.States = {
 	loadingScreen = true,
 	playerLoggedIn = false,
 	pvpMatch = false,
+	requiresReinit = false,
 };
 
 SIPPYCUP.AddonMetadata = {

--- a/Modules/Dialogs/RenameDialog.lua
+++ b/Modules/Dialogs/RenameDialog.lua
@@ -13,7 +13,7 @@ local MaxProfileNameLength = 32;
 local function validateNewName(newName, oldName)
 	if newName == "" then return false; end
 	if newName == oldName then return false; end
-	if SIPPYCUP.Database.ProfileExists(newName) then return false; end
+	if SIPPYCUP.Database:ProfileExists(newName) then return false; end
 	return true;
 end
 
@@ -28,7 +28,7 @@ StaticPopupDialogs["SIPPYCUP_RENAME_PROFILE"] = {
 	OnAccept = function(self, data)
 		local newName = string.trim(self.EditBox:GetText());
 		if data and data.oldName and newName ~= data.oldName then
-			SIPPYCUP.Database.RenameProfile(data.oldName, newName);
+			SIPPYCUP.Database:RenameProfile(data.oldName, newName);
 		end
 	end,
 	OnShow = function(self, data)
@@ -60,7 +60,7 @@ StaticPopupDialogs["SIPPYCUP_RENAME_PROFILE"] = {
 
 		local newName = string.trim(self:GetText());
 		if validateNewName(newName, data.oldName) then
-			SIPPYCUP.Database.RenameProfile(data.oldName, newName);
+			SIPPYCUP.Database:RenameProfile(data.oldName, newName);
 			StaticPopup_Hide("SIPPYCUP_RENAME_PROFILE");
 		end
 	end,

--- a/Modules/Flyway/Flyway.lua
+++ b/Modules/Flyway/Flyway.lua
@@ -4,7 +4,7 @@
 
 SIPPYCUP.Flyway = {};
 
-local SCHEMA_VERSION = 1;
+local SCHEMA_VERSION = 2;
 
 local function ApplyPatches(fromBuild, toBuild)
 	local patched = false;
@@ -22,22 +22,23 @@ local function ApplyPatches(fromBuild, toBuild)
 
 	if patched then
 		local logText = ("Patch applied from %s to %s on %s"):format(fromBuild - 1, toBuild, date("%d/%m/%y %H:%M:%S"));
-		SIPPYCUP.db.global.Flyway.Log = logText;
+		SIPPYCUP.Database:SetGlobalSetting("Flyway", { Log = logText });
 	end
 end
 
 function SIPPYCUP.Flyway:ApplyPatches()
-	-- Prevent running patches if the saved data is from a newer version than we support
-	if SIPPYCUP.db.global.Flyway and SIPPYCUP.db.global.Flyway.CurrentBuild and SIPPYCUP.db.global.Flyway.CurrentBuild > SCHEMA_VERSION then
-		SIPPYCUP_OUTPUT.Warn("Saved data is from a newer version (%s), skipping Flyway.", SIPPYCUP.db.global.Flyway.CurrentBuild);
+	local flyway = SIPPYCUP.Database:GetGlobalSetting("Flyway");
+	local currentBuild = flyway and flyway.CurrentBuild or 0;
+
+	-- Prevent running patches if saved data is from a newer version than we support
+	if currentBuild > SCHEMA_VERSION then
+		SIPPYCUP_OUTPUT.Warn("Saved data is from a newer version (%s), skipping Flyway.", currentBuild);
 		return;
 	end
 
-	SIPPYCUP.db.global.Flyway = SIPPYCUP.db.global.Flyway or {};
-
-	if not SIPPYCUP.db.global.Flyway.CurrentBuild or SIPPYCUP.db.global.Flyway.CurrentBuild < SCHEMA_VERSION then
-		ApplyPatches((SIPPYCUP.db.global.Flyway.CurrentBuild or 0) + 1, SCHEMA_VERSION);
+	if currentBuild < SCHEMA_VERSION then
+		ApplyPatches(currentBuild + 1, SCHEMA_VERSION);
 	end
 
-	SIPPYCUP.db.global.Flyway.CurrentBuild = SCHEMA_VERSION;
+	SIPPYCUP.Database:SetGlobalSetting("Flyway", { CurrentBuild = SCHEMA_VERSION });
 end

--- a/Modules/Flyway/FlywayPatches.lua
+++ b/Modules/Flyway/FlywayPatches.lua
@@ -6,7 +6,7 @@ SIPPYCUP.Flyway.Patches = {};
 
 SIPPYCUP.Flyway.Patches["1"] = {
 	run = function()
-		if not SIPPYCUP.db then
+		if not SippyCupDB or not SippyCupDB.profiles then
 			return;
 		end
 
@@ -54,7 +54,7 @@ SIPPYCUP.Flyway.Patches["1"] = {
 			winterfallFirewater = 17038;
 		};
 
-		for profileName, profileData in pairs(SIPPYCUP.db.profiles) do
+		for profileName, profileData in pairs(SippyCupDB.profiles) do
 			local newProfile = {};
 
 			for key, value in pairs(profileData) do
@@ -87,17 +87,74 @@ SIPPYCUP.Flyway.Patches["1"] = {
 			end
 
 			-- Replace old profile data with updated key mappings
-			SIPPYCUP.db.profiles[profileName] = newProfile;
+			SippyCupDB.profiles[profileName] = newProfile;
 		end
 
-		-- Reload current profile with new data, for reminders to show up.
-		local profileName = SIPPYCUP.Database.GetCurrentProfileName();
-		SIPPYCUP.Database.SetProfile(profileName);
+		-- Reload current profile so runtime references update
+		local profileName = SIPPYCUP.Database:GetProfileName();
+		SIPPYCUP.Database:SetProfile(profileName);
 
-		if SIPPYCUP.db.global.PopupIcon ~= nil then
-			SIPPYCUP.db.global.PopupIcon = nil;
+		if SIPPYCUP.Database:GetGlobalSetting("PopupIcon") then
+			SIPPYCUP.Database:SetGlobalSetting("PopupIcon", nil);
 		end
 	end,
 
 	description = "Prepare 0.3.0, updated SV profiles to using AuraID/SpellID.",
+};
+
+SIPPYCUP.Flyway.Patches["2"] = {
+	run = function()
+		if not SippyCupDB then return; end
+
+		-- Strip character-specific keys from profiles (now tracked in SippyCupCharDB)
+		if SippyCupDB.profiles then
+			local charKeys = {
+				currentStacks = true,
+				currentInstanceID = true,
+				currentItemID = true,
+				lastItemCount = true,
+			};
+
+			for _, profileData in pairs(SippyCupDB.profiles) do
+				for _, optionData in pairs(profileData) do
+					if type(optionData) == "table" then
+						for key in pairs(charKeys) do
+							optionData[key] = nil;
+						end
+					end
+				end
+			end
+		end
+
+		-- Migrate profileKeys from "Name - Realm Name" to "Name-RealmName" format
+		if SippyCupDB.profileKeys then
+			local toAdd = {};
+			local toRemove = {};
+
+			for oldKey, profileName in 	pairs(SippyCupDB.profileKeys) do
+				local name, realm = oldKey:match("^(.+) %- (.+)$");
+				if name and realm then
+					local normalizedRealm = realm:gsub("[%s%-%.]+", "");
+					local newKey = name .. "-" .. normalizedRealm;
+
+					if newKey ~= oldKey then
+						toAdd[newKey] = profileName;
+					end
+
+					toRemove[#toRemove + 1] = oldKey;
+				end
+			end
+
+			-- Apply additions first, then removals
+			for newKey, profileName in pairs(toAdd) do
+				SippyCupDB.profileKeys[newKey] = profileName;
+			end
+
+			for _, oldKey in ipairs(toRemove) do
+				SippyCupDB.profileKeys[oldKey] = nil;
+			end
+		end
+	end,
+
+	description = "Strip character-specific keys from profiles, migrate profileKeys to normalized realm format.",
 };

--- a/Modules/Flyway/FlywayPatches.lua
+++ b/Modules/Flyway/FlywayPatches.lua
@@ -153,6 +153,11 @@ SIPPYCUP.Flyway.Patches["2"] = {
 			for _, oldKey in ipairs(toRemove) do
 				SippyCupDB.profileKeys[oldKey] = nil;
 			end
+
+			-- Profile resolution needs to re-run after flyway.
+			if next(toAdd) then
+				SIPPYCUP.States.requiresReinit = true;
+			end
 		end
 	end,
 

--- a/Modules/MSP/MSP.lua
+++ b/Modules/MSP/MSP.lua
@@ -46,7 +46,7 @@ function SIPPYCUP.MSP.EnableIfAvailable()
 	if not SIPPYCUP.MSP._callbackRegistered then
 		table.insert(msp.callback["updated"], function(senderID)
 			-- If MSP status checks are off, don't do anything, or if the addon is not ready.
-			if not SIPPYCUP.global.MSPStatusCheck or not SIPPYCUP.States.addonReady then
+			if not SIPPYCUP.Database:GetGlobalSetting("MSPStatusCheck") or not SIPPYCUP.States.addonReady then
 				return;
 			end
 

--- a/Modules/Minimap/Minimap.lua
+++ b/Modules/Minimap/Minimap.lua
@@ -32,7 +32,7 @@ function SIPPYCUP.Minimap:SetupMinimapButtons()
 		OnTooltipShow = OnTooltipShow,
 	});
 
-	local minimapSettings = SIPPYCUP.Database.GetGlobalSetting("MinimapButton");
+	local minimapSettings = SIPPYCUP.Database:GetGlobalSetting("MinimapButton");
 	LibDBIcon:Register(SIPPYCUP.AddonMetadata.title, ldb, minimapSettings);
 	LibDBCompartment:Register(SIPPYCUP.AddonMetadata.title, ldb);
 
@@ -42,7 +42,7 @@ end
 ---UpdateMinimapButtons toggles visibility of minimap-related buttons based on addon settings.
 ---@return nil
 function SIPPYCUP.Minimap:UpdateMinimapButtons()
-	local minimapSettings = SIPPYCUP.Database.GetGlobalSetting("MinimapButton");
+	local minimapSettings = SIPPYCUP.Database:GetGlobalSetting("MinimapButton");
 	if minimapSettings and not minimapSettings.Hide then
 		LibDBCompartment:SetShown(SIPPYCUP.AddonMetadata.title, minimapSettings.ShowAddonCompartmentButton);
 		LibDBIcon:Refresh(SIPPYCUP.AddonMetadata.title);

--- a/Modules/Popups/Popups.lua
+++ b/Modules/Popups/Popups.lua
@@ -58,7 +58,7 @@ local sessionData = {};
 ---@return nil
 function SIPPYCUP.Popups.ResetIgnored()
 	for auraID in pairs(sessionData) do
-		local profileOptionData = SIPPYCUP.Database:GetProfileOption(auraID);
+		local profileOptionData = SIPPYCUP.Database:GetOption(auraID);
 		SIPPYCUP.Popups.Toggle(nil, auraID, profileOptionData.enable);
 	end
 
@@ -630,7 +630,7 @@ function SIPPYCUP.Popups.Toggle(itemName, auraID, enabled)
 		return;
 	end
 
-	local profileOptionData = SIPPYCUP.Database:GetProfileOption(optionData.auraID);
+	local profileOptionData = SIPPYCUP.Database:GetOption(optionData.auraID);
 	if not profileOptionData then
 		return;
 	end
@@ -766,7 +766,7 @@ function SIPPYCUP.Popups.HandlePopupAction(data, caller)
 	SIPPYCUP_OUTPUT.Debug("HandlePopupAction -", caller);
 
 	local optionData = data.optionData or SIPPYCUP.Options.ByAuraID[data.auraID];
-	local profileOptionData = data.profileOptionData or SIPPYCUP.Database:GetProfileOption(data.auraID);
+	local profileOptionData = data.profileOptionData or SIPPYCUP.Database:GetOption(data.auraID);
 
 	if not optionData or not profileOptionData or SIPPYCUP.Popups.IsIgnored(optionData.auraID) then
 		return;

--- a/Modules/Popups/Popups.lua
+++ b/Modules/Popups/Popups.lua
@@ -58,8 +58,8 @@ local sessionData = {};
 ---@return nil
 function SIPPYCUP.Popups.ResetIgnored()
 	for auraID in pairs(sessionData) do
-		local profileOptionData = SIPPYCUP.Database:GetOption(auraID);
-		SIPPYCUP.Popups.Toggle(nil, auraID, profileOptionData.enable);
+		local profileOptionData = SIPPYCUP.Database.auraToProfile[auraID];
+		SIPPYCUP.Popups.Toggle(nil, auraID, profileOptionData and profileOptionData.enable or false);
 	end
 
 	wipe(sessionData);
@@ -766,6 +766,7 @@ function SIPPYCUP.Popups.HandlePopupAction(data, caller)
 	SIPPYCUP_OUTPUT.Debug("HandlePopupAction -", caller);
 
 	local optionData = data.optionData or SIPPYCUP.Options.ByAuraID[data.auraID];
+	local isFallback = data.profileOptionData == nil;
 	local profileOptionData = data.profileOptionData or SIPPYCUP.Database:GetOption(data.auraID);
 
 	if not optionData or not profileOptionData or SIPPYCUP.Popups.IsIgnored(optionData.auraID) then
@@ -966,10 +967,12 @@ function SIPPYCUP.Popups.HandlePopupAction(data, caller)
 
 	local requiredStacks = profileOptionData.desiredStacks - profileOptionData.currentStacks;
 
-	SIPPYCUP.Database:SetCharSetting(auraID, "currentStacks", profileOptionData.currentStacks);
-	SIPPYCUP.Database:SetCharSetting(auraID, "currentInstanceID", profileOptionData.currentInstanceID);
-	SIPPYCUP.Database:SetCharSetting(auraID, "currentItemID", profileOptionData.currentItemID);
-	SIPPYCUP.Database:SetCharSetting(auraID, "lastItemCount", profileOptionData.lastItemCount);
+	if isFallback then
+		-- Temporary GetOption copy; commit to both lookup tables and charDB.
+		SIPPYCUP.Database:CommitFullState(auraID, profileOptionData);
+	else
+		SIPPYCUP.Database:CommitCharState(auraID, profileOptionData);
+	end
 
 	SIPPYCUP.Popups.HandleReminderPopup({
 		active = active,

--- a/Modules/Popups/Popups.lua
+++ b/Modules/Popups/Popups.lua
@@ -11,12 +11,13 @@ SIPPYCUP.Popups.Reason = {
 	REMOVAL = 1,
 	PRE_EXPIRATION = 2,
 	TOGGLE = 3,
+	STARTUP = 4,
 };
 
 ---PlayPopupSound plays the chosen alert sound during a popup.
 ---@return nil
 local function PlayPopupSound()
-	local soundPath = SharedMedia:Fetch("sound", SIPPYCUP.global.AlertSoundID);
+	local soundPath = SharedMedia:Fetch("sound", SIPPYCUP.Database:GetGlobalSetting("AlertSoundID"));
 	if soundPath then
 		PlaySoundFile(soundPath, "Master");
 	end
@@ -35,16 +36,16 @@ local function HandleAlerts()
 	end
 	alertThrottle = true;
 
-	if SIPPYCUP.global.AlertSound then
+	if SIPPYCUP.Database:GetGlobalSetting("AlertSound") then
 		PlayPopupSound();
 	end
-	if SIPPYCUP.global.FlashTaskbar then
+	if SIPPYCUP.Database:GetGlobalSetting("FlashTaskbar") then
 		FlashClientIcon();
 	end
 
 	-- We save the last profile an alert played for, so we can play a new
 	-- alert for cases where a popup exists on both profiles when it is switched.
-	lastProfileAlert = SIPPYCUP.Database.GetCurrentProfileName();
+	lastProfileAlert = SIPPYCUP.Database:GetProfileName();
 
 	RunNextFrame(function()
 		alertThrottle = false;
@@ -57,7 +58,7 @@ local sessionData = {};
 ---@return nil
 function SIPPYCUP.Popups.ResetIgnored()
 	for auraID in pairs(sessionData) do
-		local profileOptionData = SIPPYCUP.Profile[auraID];
+		local profileOptionData = SIPPYCUP.Database:GetProfileOption(auraID);
 		SIPPYCUP.Popups.Toggle(nil, auraID, profileOptionData.enable);
 	end
 
@@ -108,8 +109,8 @@ local activePopupByLoc = SIPPYCUP.Popups.activeByLoc;
 local function CalculatePopupOffset(index)
 	local position = "TOP"; -- default fallback
 
-	if SIPPYCUP and SIPPYCUP.db and SIPPYCUP.db.global and SIPPYCUP.global.PopupPosition then
-		position = SIPPYCUP.global.PopupPosition;
+	if SIPPYCUP and SIPPYCUP.Database then
+		position = SIPPYCUP.Database:GetGlobalSetting("PopupPosition");
 	end
 
 	if position == "BOTTOM" then
@@ -551,7 +552,7 @@ function SIPPYCUP.Popups.HandleReminderPopup(data, templateTypeID)
 			end
 
 			-- If user wants a missing reminder, we'll do that now (unless it's a toy as that has no item counts).
-			if data.itemCount < data.profileOptionData.desiredStacks and SIPPYCUP.global.InsufficientReminder and data.optionData.type ~= SIPPYCUP.Options.Type.TOY then
+			if data.itemCount < data.profileOptionData.desiredStacks and SIPPYCUP.Database:GetGlobalSetting("InsufficientReminder") and data.optionData.type ~= SIPPYCUP.Options.Type.TOY then
 				SIPPYCUP.Popups.HandleReminderPopup(data, 1);
 			end
 			return;
@@ -592,7 +593,7 @@ function SIPPYCUP.Popups.HandleReminderPopup(data, templateTypeID)
 		activePopups[#activePopups + 1] = popup; -- Add to active list only if it's a new instance
 		activePopupByLoc[loc] = popup; -- Store in lookup for loc-based replacement
 		shouldPlayAlert = true;
-	elseif lastProfileAlert ~= SIPPYCUP.Database.GetCurrentProfileName() then
+	elseif lastProfileAlert ~= SIPPYCUP.Database:GetProfileName() then
 		-- If profile change happens, fire an alert as-is for popups (throttle will still hold them)
 		shouldPlayAlert = true;
 	elseif data.reason == SIPPYCUP.Popups.Reason.REMOVAL then
@@ -629,13 +630,13 @@ function SIPPYCUP.Popups.Toggle(itemName, auraID, enabled)
 		return;
 	end
 
-	local profileOptionData = SIPPYCUP.Profile[optionData.auraID];
+	local profileOptionData = SIPPYCUP.Database:GetProfileOption(optionData.auraID);
 	if not profileOptionData then
 		return;
 	end
 
 	-- Update aura map incrementally for this option
-	SIPPYCUP.Database.UpdateAuraMapForOption(profileOptionData, enabled);
+	SIPPYCUP.Database:UpdateAuraMapForOption(profileOptionData, enabled);
 
 	-- If the option is not enabled, kill all its associated popups and timers!
 	if not enabled then
@@ -725,7 +726,7 @@ function SIPPYCUP.Popups.QueuePopupAction(data,  caller)
 	end
 
 	-- If MSP status checks are on and the character is currently OOC, we skip everything.
-	if SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.global.MSPStatusCheck then
+	if SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.Database:GetGlobalSetting("MSPStatusCheck") then
 		local _, _, isIC = SIPPYCUP.MSP.CheckRPStatus();
 		if not isIC then
 			return;
@@ -765,7 +766,7 @@ function SIPPYCUP.Popups.HandlePopupAction(data, caller)
 	SIPPYCUP_OUTPUT.Debug("HandlePopupAction -", caller);
 
 	local optionData = data.optionData or SIPPYCUP.Options.ByAuraID[data.auraID];
-	local profileOptionData = data.profileOptionData or SIPPYCUP.Profile[data.auraID];
+	local profileOptionData = data.profileOptionData or SIPPYCUP.Database:GetProfileOption(data.auraID);
 
 	if not optionData or not profileOptionData or SIPPYCUP.Popups.IsIgnored(optionData.auraID) then
 		return;
@@ -964,6 +965,11 @@ function SIPPYCUP.Popups.HandlePopupAction(data, caller)
 	end
 
 	local requiredStacks = profileOptionData.desiredStacks - profileOptionData.currentStacks;
+
+	SIPPYCUP.Database:SetCharSetting(auraID, "currentStacks", profileOptionData.currentStacks);
+	SIPPYCUP.Database:SetCharSetting(auraID, "currentInstanceID", profileOptionData.currentInstanceID);
+	SIPPYCUP.Database:SetCharSetting(auraID, "currentItemID", profileOptionData.currentItemID);
+	SIPPYCUP.Database:SetCharSetting(auraID, "lastItemCount", profileOptionData.lastItemCount);
 
 	SIPPYCUP.Popups.HandleReminderPopup({
 		active = active,

--- a/SippyCup.lua
+++ b/SippyCup.lua
@@ -125,7 +125,7 @@ function SIPPYCUP_Addon:OnInitialPlayerInWorld()
 	-- Re-resolve active profile only if flyway or Unknown migration changed things.
 	if SIPPYCUP.States.requiresReinit then
 		SIPPYCUP.States.requiresReinit = false;
-		SIPPYCUP.Database:ResolveActiveProfile();
+		SIPPYCUP.Database:ResolveActiveProfile(realCharKey);
 	end
 
 	SIPPYCUP.Minimap:SetupMinimapButtons();

--- a/SippyCup.lua
+++ b/SippyCup.lua
@@ -14,18 +14,8 @@ end
 
 ---OnInitialize Loads saved variables, sets up database, options, and slash commands.
 function SIPPYCUP_Addon:OnInitialize()
-	if not SippyCupDB then
-		SippyCupDB = {
-			global = {},
-			profileKeys = {},
-			profiles = {},
-		};
-	end
-
-	SIPPYCUP.db = SippyCupDB;
-
 	-- Set up DB internals & Options
-	SIPPYCUP.Database.Setup();
+	SIPPYCUP.Database:Init();
 	SIPPYCUP.Options.Setup();
 
 	-- Register slash commands
@@ -112,21 +102,28 @@ function SIPPYCUP_Addon:OnInitialPlayerInWorld()
 	-- Prepare our MSP checks.
 	SIPPYCUP.MSP.EnableIfAvailable(); -- True/False if enable successfully, we don't need that info right now.
 	-- Depending on if MSP status checks are on or off, we check differently.
-	SIPPYCUP.Options.RefreshStackSizes(SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.global.MSPStatusCheck);
+	SIPPYCUP.Options.RefreshStackSizes(SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.Database:GetGlobalSetting("MSPStatusCheck"));
 
-	local realCharKey = SIPPYCUP.Database.GetUnitName();
+	local realCharKey = SIPPYCUP_UTILS.GetUnitName();
 	if realCharKey then
-		local db = SIPPYCUP.db;
-		if db.profileKeys["Unknown"] and not db.profileKeys[realCharKey] then
-			db.profileKeys[realCharKey] = db.profileKeys["Unknown"];
-			db.profileKeys["Unknown"] = nil;
-			-- Optional: move profile data as well if you saved it under Unknown profile
-			-- local profileName = db.profileKeys[realCharKey];
-			-- if db.profiles and db.profiles[profileName] then
-			--     db.profiles[profileName] = db.profiles[profileName] or {};
-			-- end
+		local db = SippyCupDB;
+
+		-- Check if "Unknown" profile exists and realCharKey does not yet have a profile
+		if db.profiles["Unknown"] and not db.profileKeys[realCharKey] then
+			-- Move the profile data from "Unknown" to realCharKey
+			db.profiles[realCharKey] = db.profiles["Unknown"];
+			db.profiles["Unknown"] = nil;
+
+			-- Update profileKeys mapping
+			for key, profileName in pairs(db.profileKeys) do
+				if profileName == "Unknown" then
+					db.profileKeys[key] = realCharKey;
+				end
+			end
 		end
-		SIPPYCUP.Database.Setup();
+
+		-- Re-initialize database so currentProfile points to realCharKey
+		SIPPYCUP.Database:Init();
 	end
 
 	-- Adapt saved variables structures between versions
@@ -134,8 +131,8 @@ function SIPPYCUP_Addon:OnInitialPlayerInWorld()
 
 	SIPPYCUP.Minimap:SetupMinimapButtons();
 
-	if SIPPYCUP.global.WelcomeMessage then
-		SIPPYCUP_OUTPUT.Write(L.WELCOMEMSG_VERSION:format(SIPPYCUP.Database.GetCurrentProfileName(), SIPPYCUP.AddonMetadata.version));
+	if SIPPYCUP.Database:GetGlobalSetting("WelcomeMessage") then
+		SIPPYCUP_OUTPUT.Write(L.WELCOMEMSG_VERSION:format(SIPPYCUP.Database:GetProfileName(), SIPPYCUP.AddonMetadata.version));
 		SIPPYCUP_OUTPUT.Write(L.WELCOMEMSG_OPTIONS);
 	end
 
@@ -161,7 +158,7 @@ function SIPPYCUP_Addon:ADDON_RESTRICTION_STATE_CHANGED(_, type, state) -- luach
 		self:StartContinuousCheck();
 		SIPPYCUP.Popups.HandleDeferredActions("combat");
 		-- We also fire a refresh, because in BGs/combat options might have changed.
-		SIPPYCUP.Options.RefreshStackSizes(SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.global.MSPStatusCheck);
+		SIPPYCUP.Options.RefreshStackSizes(SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.Database:GetGlobalSetting("MSPStatusCheck"));
 	end
 end
 
@@ -205,7 +202,7 @@ function SIPPYCUP_Addon:PLAYER_REGEN_ENABLED()
 	self:StartContinuousCheck();
 	-- Show 'combat' popups deferred by DeferAllRefreshPopups (reason 1).
 	SIPPYCUP.Popups.HandleDeferredActions("combat");
-	SIPPYCUP.Options.RefreshStackSizes(SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.global.MSPStatusCheck);
+	SIPPYCUP.Options.RefreshStackSizes(SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.Database:GetGlobalSetting("MSPStatusCheck"));
 end
 
 ---UNIT_AURA Handles player aura updates, flags bag desync, and triggers aura conversion.
@@ -301,7 +298,7 @@ SIPPYCUP.Callbacks:RegisterCallback(SIPPYCUP.Events.LOADING_SCREEN_ENDED, functi
 			SIPPYCUP.States.pvpMatch = false;
 			SIPPYCUP.Popups.HandleDeferredActions("combat");
 			-- We also fire a refresh, because during loading screens options can't be changed, but in BGs/combat they might.
-			SIPPYCUP.Options.RefreshStackSizes(SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.global.MSPStatusCheck);
+			SIPPYCUP.Options.RefreshStackSizes(SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.Database:GetGlobalSetting("MSPStatusCheck"));
 		end
 
 		-- isFullUpdate can pass through loading screens (but our code can't), so handle it now.

--- a/SippyCup.lua
+++ b/SippyCup.lua
@@ -92,7 +92,9 @@ end
 ---OnInitialPlayerInWorld Runs initial setup after the player enters the world for the first time.
 ---Handles MSP checks, DB profile migration, saved variable patches, and minimap setup.
 function SIPPYCUP_Addon:OnInitialPlayerInWorld()
-	-- Do nothing when you are on a PvP-enabled map (Arenas, BGs, etc.)
+	-- Adapt saved variables structures between versions
+	SIPPYCUP.Flyway:ApplyPatches();
+
 	local inPvp = C_RestrictedActions.IsAddOnRestrictionActive(Enum.AddOnRestrictionType.PvPMatch) or C_PvP.IsActiveBattlefield();
 	if inPvp then
 		SIPPYCUP.States.pvpMatch = true;
@@ -101,33 +103,30 @@ function SIPPYCUP_Addon:OnInitialPlayerInWorld()
 
 	-- Prepare our MSP checks.
 	SIPPYCUP.MSP.EnableIfAvailable(); -- True/False if enable successfully, we don't need that info right now.
-	-- Depending on if MSP status checks are on or off, we check differently.
-	SIPPYCUP.Options.RefreshStackSizes(SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.Database:GetGlobalSetting("MSPStatusCheck"));
 
+	-- Unknown profile migration
 	local realCharKey = SIPPYCUP_UTILS.GetUnitName();
 	if realCharKey then
 		local db = SippyCupDB;
-
-		-- Check if "Unknown" profile exists and realCharKey does not yet have a profile
 		if db.profiles["Unknown"] and not db.profileKeys[realCharKey] then
-			-- Move the profile data from "Unknown" to realCharKey
 			db.profiles[realCharKey] = db.profiles["Unknown"];
 			db.profiles["Unknown"] = nil;
 
-			-- Update profileKeys mapping
 			for key, profileName in pairs(db.profileKeys) do
 				if profileName == "Unknown" then
 					db.profileKeys[key] = realCharKey;
 				end
 			end
-		end
 
-		-- Re-initialize database so currentProfile points to realCharKey
-		SIPPYCUP.Database:Init();
+			SIPPYCUP.States.requiresReinit = true;
+		end
 	end
 
-	-- Adapt saved variables structures between versions
-	SIPPYCUP.Flyway:ApplyPatches();
+	-- Re-resolve active profile only if flyway or Unknown migration changed things.
+	if SIPPYCUP.States.requiresReinit then
+		SIPPYCUP.States.requiresReinit = false;
+		SIPPYCUP.Database:ResolveActiveProfile();
+	end
 
 	SIPPYCUP.Minimap:SetupMinimapButtons();
 
@@ -137,6 +136,8 @@ function SIPPYCUP_Addon:OnInitialPlayerInWorld()
 	end
 
 	SIPPYCUP.States.addonReady = true;
+	-- Depending on if MSP status checks are on or off, we check differently.
+	SIPPYCUP.Options.RefreshStackSizes(SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.Database:GetGlobalSetting("MSPStatusCheck"));
 end
 
 ---BAG_UPDATE_DELAYED Handles delayed bag updates and triggers item update processing.

--- a/SippyCup.toc
+++ b/SippyCup.toc
@@ -22,6 +22,7 @@
 
 ## OptionalDeps: ElvUI, totalRP3, MyRolePlay, XRP
 ## SavedVariables: SippyCupDB
+## SavedVariablesPerCharacter: SippyCupCharDB
 
 ## X-Build: 120001, 120000, 110207
 ## X-Category: Roleplay

--- a/UI/Config.lua
+++ b/UI/Config.lua
@@ -1650,7 +1650,7 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 						end,
 						set = function(val)
 							SIPPYCUP.Database:SetProfileSetting(sliderProfileKey, "desiredStacks", val);
-							local profileOptionData = SIPPYCUP.Database:GetProfileOption(sliderProfileKey);
+							local profileOptionData = SIPPYCUP.Database:GetOption(sliderProfileKey);
 							if profileOptionData.enable then
 								SIPPYCUP.Popups.Toggle(consumableName, consumableAura, true);
 							end
@@ -1785,7 +1785,7 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 						end,
 						set = function(val)
 							SIPPYCUP.Database:SetProfileSetting(sliderProfileKey, "desiredStacks", val);
-							local profileOptionData = SIPPYCUP.Database:GetProfileOption(sliderProfileKey);
+							local profileOptionData = SIPPYCUP.Database:GetOption(sliderProfileKey);
 							if profileOptionData.enable then
 								SIPPYCUP.Popups.Toggle(toyName, toyAura, true);
 							end

--- a/UI/Config.lua
+++ b/UI/Config.lua
@@ -1622,10 +1622,10 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 					stacks = optionData.stacks,
 					buildAdded = optionData.buildAdded,
 					get = function()
-						return SIPPYCUP.Database:GetAuraSetting(checkboxProfileKey, "enable");
+						return SIPPYCUP.Database:GetProfileSetting(checkboxProfileKey, "enable");
 					end,
 					set = function(val)
-						SIPPYCUP.Database:SetAuraSetting(checkboxProfileKey, "enable", val);
+						SIPPYCUP.Database:SetProfileSetting(checkboxProfileKey, "enable", val);
 						SIPPYCUP.Popups.Toggle(consumableName, consumableAura, val);
 					end,
 				};
@@ -1643,13 +1643,13 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 						max = optionData.maxStacks,
 						step = 1,
 						disabled = function()
-							return not SIPPYCUP.Database:GetAuraSetting(sliderProfileKey, "enable");
+							return not SIPPYCUP.Database:GetProfileSetting(sliderProfileKey, "enable");
 						end,
 						get = function()
-							return SIPPYCUP.Database:GetAuraSetting(sliderProfileKey, "desiredStacks");
+							return SIPPYCUP.Database:GetProfileSetting(sliderProfileKey, "desiredStacks");
 						end,
 						set = function(val)
-							SIPPYCUP.Database:SetAuraSetting(sliderProfileKey, "desiredStacks", val);
+							SIPPYCUP.Database:SetProfileSetting(sliderProfileKey, "desiredStacks", val);
 							local profileOptionData = SIPPYCUP.Database:GetProfileOption(sliderProfileKey);
 							if profileOptionData.enable then
 								SIPPYCUP.Popups.Toggle(consumableName, consumableAura, true);
@@ -1758,10 +1758,10 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 						return IsToyDisabled(toyID);
 					end,
 					get = function()
-						return SIPPYCUP.Database:GetAuraSetting(checkboxProfileKey, "enable");
+						return SIPPYCUP.Database:GetProfileSetting(checkboxProfileKey, "enable");
 					end,
 					set = function(val)
-						SIPPYCUP.Database:SetAuraSetting(checkboxProfileKey, "enable", val);
+						SIPPYCUP.Database:SetProfileSetting(checkboxProfileKey, "enable", val);
 						SIPPYCUP.Popups.Toggle(toyName, toyAura, val);
 					end,
 				};
@@ -1778,13 +1778,13 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 						max = optionData.maxStacks,
 						step = 1,
 						disabled = function()
-							return not SIPPYCUP.Database:GetAuraSetting(sliderProfileKey, "enable");
+							return not SIPPYCUP.Database:GetProfileSetting(sliderProfileKey, "enable");
 						end,
 						get = function()
-							return SIPPYCUP.Database:GetAuraSetting(sliderProfileKey, "desiredStacks");
+							return SIPPYCUP.Database:GetProfileSetting(sliderProfileKey, "desiredStacks");
 						end,
 						set = function(val)
-							SIPPYCUP.Database:SetAuraSetting(sliderProfileKey, "desiredStacks", val);
+							SIPPYCUP.Database:SetProfileSetting(sliderProfileKey, "desiredStacks", val);
 							local profileOptionData = SIPPYCUP.Database:GetProfileOption(sliderProfileKey);
 							if profileOptionData.enable then
 								SIPPYCUP.Popups.Toggle(toyName, toyAura, true);

--- a/UI/Config.lua
+++ b/UI/Config.lua
@@ -526,12 +526,12 @@ local function CreateInset(parent, insetData)
 				printCheckbox:SetSize(22, 22);
 				ElvUI.RegisterSkinnableElement(printCheckbox, "checkbox");
 
-				printCheckbox:SetChecked(SIPPYCUP.Database.GetGlobalSetting("DebugOutput"));
+				printCheckbox:SetChecked(SIPPYCUP.Database:GetGlobalSetting("DebugOutput"));
 
 				AttachTooltip(printCheckbox, "Enable Debug Output", "Click this to enable the debug prints.|n|nIf you see this without knowing what debug is, you might've done something wrong!");
 
 				printCheckbox:SetScript("OnClick", function(self)
-					SIPPYCUP.Database.SetGlobalSetting("DebugOutput", self:GetChecked());
+					SIPPYCUP.Database:SetGlobalSetting("DebugOutput", self:GetChecked());
 				end);
 			end
 		end
@@ -1127,17 +1127,12 @@ function SIPPYCUP_ConfigMixin:SwitchProfileValues()
 			local data = widget.data;
 			if data and type(data.get) == "function" then
 				local value = data.get();
-				local hasSet = type(data.set) == "function";
 
 				if widget.SetChecked and widget.GetChecked then
 					local oldVal = widget:GetChecked();
 					if oldVal ~= value then
 						widget:SetChecked(value);
 					end
-					if hasSet then
-						data.set(value);
-					end
-
 				elseif widget.SetValue and widget.GetValue then
 					local oldVal = widget:GetValue();
 					if oldVal ~= value then
@@ -1146,11 +1141,6 @@ function SIPPYCUP_ConfigMixin:SwitchProfileValues()
 							widget.Text:SetText(string.format("%s: %d", data.label or "", math.floor(value + 0.5)));
 						end
 					end
-
-					if hasSet then
-						data.set(value);
-					end
-
 					if type(data.disabled) == "function" then
 						local isDisabled = data.disabled();
 						widget:SetEnabled(not isDisabled);
@@ -1319,10 +1309,10 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 			label = L.OPTIONS_GENERAL_WELCOME_NAME,
 			tooltip = L.OPTIONS_GENERAL_WELCOME_DESC,
 			get = function()
-				return SIPPYCUP.Database.GetGlobalSetting("WelcomeMessage");
+				return SIPPYCUP.Database:GetGlobalSetting("WelcomeMessage");
 			end,
 			set = function(val)
-				SIPPYCUP.Database.SetGlobalSetting("WelcomeMessage", val);
+				SIPPYCUP.Database:SetGlobalSetting("WelcomeMessage", val);
 			end,
 		},
 		{
@@ -1330,13 +1320,13 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 			label = L.OPTIONS_GENERAL_MINIMAPBUTTON_NAME,
 			tooltip = L.OPTIONS_GENERAL_MINIMAPBUTTON_DESC,
 			get = function()
-				return not SIPPYCUP.Database.GetGlobalSetting("MinimapButton").Hide;
+				return not SIPPYCUP.Database:GetGlobalSetting("MinimapButton").Hide;
 			end,
 			set = function(val)
 				-- Update with inversion: save 'Hide' as NOT val
-				local minimapSettings = SIPPYCUP.Database.GetGlobalSetting("MinimapButton");
+				local minimapSettings = SIPPYCUP.Database:GetGlobalSetting("MinimapButton");
 				minimapSettings.Hide = not val;
-				SIPPYCUP.Database.SetGlobalSetting("MinimapButton", minimapSettings);
+				SIPPYCUP.Database:SetGlobalSetting("MinimapButton", minimapSettings);
 				SIPPYCUP.Minimap:UpdateMinimapButtons();
 			end,
 		},
@@ -1345,12 +1335,12 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 			label = L.OPTIONS_GENERAL_ADDONCOMPARTMENT_NAME,
 			tooltip = L.OPTIONS_GENERAL_ADDONCOMPARTMENT_DESC,
 			get = function()
-				return SIPPYCUP.Database.GetGlobalSetting("MinimapButton").ShowAddonCompartmentButton;
+				return SIPPYCUP.Database:GetGlobalSetting("MinimapButton").ShowAddonCompartmentButton;
 			end,
 			set = function(val)
-				local minimapSettings = SIPPYCUP.Database.GetGlobalSetting("MinimapButton");
+				local minimapSettings = SIPPYCUP.Database:GetGlobalSetting("MinimapButton");
 				minimapSettings.ShowAddonCompartmentButton = val;
-				SIPPYCUP.Database.SetGlobalSetting("MinimapButton", minimapSettings);
+				SIPPYCUP.Database:SetGlobalSetting("MinimapButton", minimapSettings);
 				SIPPYCUP.Minimap:UpdateMinimapButtons();
 			end,
 		},
@@ -1360,12 +1350,12 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 			tooltip = L.OPTIONS_GENERAL_NEW_FEATURE_NOTIFICATION_DESC,
 			notificationToggle = true,
 			get = function()
-				return SIPPYCUP.Database.GetGlobalSetting("NewFeatureNotification");
+				return SIPPYCUP.Database:GetGlobalSetting("NewFeatureNotification");
 			end,
 			set = function(val)
 				SIPPYCUP.Popups.CreateReloadPopup(
 					function() -- ACCEPT
-						SIPPYCUP.Database.SetGlobalSetting("NewFeatureNotification", val);
+						SIPPYCUP.Database:SetGlobalSetting("NewFeatureNotification", val);
 						ReloadUI();
 					end
 				);
@@ -1387,12 +1377,12 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 			label = L.OPTIONS_GENERAL_POPUPS_PRE_EXPIRATION_CHECKS_ENABLE,
 			tooltip = L.OPTIONS_GENERAL_POPUPS_PRE_EXPIRATION_CHECKS_ENABLE_DESC,
 			get = function()
-				return SIPPYCUP.Database.GetGlobalSetting("PreExpirationChecks");
+				return SIPPYCUP.Database:GetGlobalSetting("PreExpirationChecks");
 			end,
 			set = function(val)
-				SIPPYCUP.Database.SetGlobalSetting("PreExpirationChecks", val);
+				SIPPYCUP.Database:SetGlobalSetting("PreExpirationChecks", val);
 				if val then
-					SIPPYCUP.Options.RefreshStackSizes(SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.global.MSPStatusCheck, false, true);
+					SIPPYCUP.Options.RefreshStackSizes(SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.Database:GetGlobalSetting("MSPStatusCheck"), false, true);
 				else
 					local reason = SIPPYCUP.Popups.Reason.PRE_EXPIRATION;
 					SIPPYCUP.Auras.CancelAllPreExpirationTimers();
@@ -1410,18 +1400,18 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 			max = 5,
 			step = 1,
 			disabled = function()
-				return not SIPPYCUP.Database.GetGlobalSetting("PreExpirationChecks");
+				return not SIPPYCUP.Database:GetGlobalSetting("PreExpirationChecks");
 			end,
 			get = function()
-				return SIPPYCUP.Database.GetGlobalSetting("PreExpirationLeadTimer");
+				return SIPPYCUP.Database:GetGlobalSetting("PreExpirationLeadTimer");
 			end,
 			set = function(val)
-				SIPPYCUP.Database.SetGlobalSetting("PreExpirationLeadTimer", val);
+				SIPPYCUP.Database:SetGlobalSetting("PreExpirationLeadTimer", val);
 				local reason = SIPPYCUP.Popups.Reason.PRE_EXPIRATION;
 				SIPPYCUP.Auras.CancelAllPreExpirationTimers();
 				SIPPYCUP.Items.CancelAllItemTimers(reason);
 				SIPPYCUP.Popups.HideAllRefreshPopups(reason);
-				SIPPYCUP.Options.RefreshStackSizes(SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.global.MSPStatusCheck, false, true);
+				SIPPYCUP.Options.RefreshStackSizes(SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.Database:GetGlobalSetting("MSPStatusCheck"), false, true);
 			end,
 		},
 		{
@@ -1429,10 +1419,10 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 			label = L.OPTIONS_GENERAL_POPUPS_INSUFFICIENT_REMINDER_ENABLE,
 			tooltip = L.OPTIONS_GENERAL_POPUPS_INSUFFICIENT_REMINDER_ENABLE_DESC,
 			get = function()
-				return SIPPYCUP.Database.GetGlobalSetting("InsufficientReminder");
+				return SIPPYCUP.Database:GetGlobalSetting("InsufficientReminder");
 			end,
 			set = function(val)
-				SIPPYCUP.Database.SetGlobalSetting("InsufficientReminder", val);
+				SIPPYCUP.Database:SetGlobalSetting("InsufficientReminder", val);
 			end,
 		},
 		{
@@ -1441,10 +1431,10 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 			tooltip = L.OPTIONS_GENERAL_POPUPS_TRACK_TOY_ITEM_CD_ENABLE_DESC,
 			buildAdded = "0.6.0|120000",
 			get = function()
-				return SIPPYCUP.Database.GetGlobalSetting("UseToyCooldown");
+				return SIPPYCUP.Database:GetGlobalSetting("UseToyCooldown");
 			end,
 			set = function(val)
-				SIPPYCUP.Database.SetGlobalSetting("UseToyCooldown", val);
+				SIPPYCUP.Database:SetGlobalSetting("UseToyCooldown", val);
 			end,
 		},
 		{
@@ -1478,10 +1468,10 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 				"BOTTOM",
 			},
 			get = function()
-				return SIPPYCUP.Database.GetGlobalSetting("PopupPosition");
+				return SIPPYCUP.Database:GetGlobalSetting("PopupPosition");
 			end,
 			set = function(val)
-				SIPPYCUP.Database.SetGlobalSetting("PopupPosition", val);
+				SIPPYCUP.Database:SetGlobalSetting("PopupPosition", val);
 			end,
 		},
 	};
@@ -1494,10 +1484,10 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 			label = BINDING_NAME_TOGGLESOUND,
 			tooltip = L.OPTIONS_GENERAL_POPUPS_SOUND_ENABLE_DESC,
 			get = function()
-				return SIPPYCUP.Database.GetGlobalSetting("AlertSound");
+				return SIPPYCUP.Database:GetGlobalSetting("AlertSound");
 			end,
 			set = function(val)
-				SIPPYCUP.Database.SetGlobalSetting("AlertSound", val);
+				SIPPYCUP.Database:SetGlobalSetting("AlertSound", val);
 			end,
 		},
 		{
@@ -1507,16 +1497,16 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 			align = "right",
 			values = soundList,
 			disabled = function()
-				return not SIPPYCUP.Database.GetGlobalSetting("AlertSound");
+				return not SIPPYCUP.Database:GetGlobalSetting("AlertSound");
 			end,
 			get = function()
-				return SIPPYCUP.Database.GetGlobalSetting("AlertSoundID");
+				return SIPPYCUP.Database:GetGlobalSetting("AlertSoundID");
 			end,
 			set = function(val)
 				local soundPath = SharedMedia:Fetch("sound", val);
 				if soundPath then
 					PlaySoundFile(soundPath, "Master");
-					SIPPYCUP.Database.SetGlobalSetting("AlertSoundID", val);
+					SIPPYCUP.Database:SetGlobalSetting("AlertSoundID", val);
 				end
 			end,
 		},
@@ -1525,10 +1515,10 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 			label = L.OPTIONS_GENERAL_POPUPS_FLASHTASKBAR_ENABLE,
 			tooltip = L.OPTIONS_GENERAL_POPUPS_FLASHTASKBAR_ENABLE_DESC,
 			get = function()
-				return SIPPYCUP.Database.GetGlobalSetting("FlashTaskbar");
+				return SIPPYCUP.Database:GetGlobalSetting("FlashTaskbar");
 			end,
 			set = function(val)
-				SIPPYCUP.Database.SetGlobalSetting("FlashTaskbar", val);
+				SIPPYCUP.Database:SetGlobalSetting("FlashTaskbar", val);
 			end,
 		},
 	};
@@ -1546,10 +1536,10 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 				return not SIPPYCUP.MSP.IsEnabled();
 			end,
 			get = function()
-				return SIPPYCUP.Database.GetGlobalSetting("MSPStatusCheck");
+				return SIPPYCUP.Database:GetGlobalSetting("MSPStatusCheck");
 			end,
 			set = function(val)
-				SIPPYCUP.Database.SetGlobalSetting("MSPStatusCheck", val);
+				SIPPYCUP.Database:SetGlobalSetting("MSPStatusCheck", val);
 				SIPPYCUP.MSP.CheckRPStatus();
 				if val then
 					SIPPYCUP.Options.RefreshStackSizes(val);
@@ -1632,10 +1622,10 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 					stacks = optionData.stacks,
 					buildAdded = optionData.buildAdded,
 					get = function()
-						return SIPPYCUP.Database.GetSetting(checkboxProfileKey).enable;
+						return SIPPYCUP.Database:GetAuraSetting(checkboxProfileKey, "enable");
 					end,
 					set = function(val)
-						SIPPYCUP.Database.SetSetting(checkboxProfileKey, { enable = val });
+						SIPPYCUP.Database:SetAuraSetting(checkboxProfileKey, "enable", val);
 						SIPPYCUP.Popups.Toggle(consumableName, consumableAura, val);
 					end,
 				};
@@ -1653,17 +1643,18 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 						max = optionData.maxStacks,
 						step = 1,
 						disabled = function()
-							return not SIPPYCUP.Database.GetSetting(sliderProfileKey).enable;
+							return not SIPPYCUP.Database:GetAuraSetting(sliderProfileKey, "enable");
 						end,
 						get = function()
-							return SIPPYCUP.Database.GetSetting(sliderProfileKey).desiredStacks;
+							return SIPPYCUP.Database:GetAuraSetting(sliderProfileKey, "desiredStacks");
 						end,
 						set = function(val)
-							SIPPYCUP.Database.SetSetting(sliderProfileKey, { desiredStacks = val });
-							if SIPPYCUP.Profile[sliderProfileKey].enable then
+							SIPPYCUP.Database:SetAuraSetting(sliderProfileKey, "desiredStacks", val);
+							local profileOptionData = SIPPYCUP.Database:GetProfileOption(sliderProfileKey);
+							if profileOptionData.enable then
 								SIPPYCUP.Popups.Toggle(consumableName, consumableAura, true);
 							end
-						end,
+						end
 					};
 				end
 			end
@@ -1683,18 +1674,18 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 					step = 1,
 					height = 35,
 					disabled = function()
-						return not SIPPYCUP.Database.GetGlobalSetting("ProjectionPrismPreExpirationLeadTimer");
+						return not SIPPYCUP.Database:GetGlobalSetting("ProjectionPrismPreExpirationLeadTimer");
 					end,
 					get = function()
-						return SIPPYCUP.Database.GetGlobalSetting("ProjectionPrismPreExpirationLeadTimer");
+						return SIPPYCUP.Database:GetGlobalSetting("ProjectionPrismPreExpirationLeadTimer");
 					end,
 					set = function(val)
-						SIPPYCUP.Database.SetGlobalSetting("ProjectionPrismPreExpirationLeadTimer", val);
+						SIPPYCUP.Database:SetGlobalSetting("ProjectionPrismPreExpirationLeadTimer", val);
 						local reason = SIPPYCUP.Popups.Reason.PRE_EXPIRATION;
 						SIPPYCUP.Auras.CancelAllPreExpirationTimers();
 						SIPPYCUP.Items.CancelAllItemTimers(reason);
 						SIPPYCUP.Popups.HideAllRefreshPopups(reason);
-						SIPPYCUP.Options.RefreshStackSizes(SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.global.MSPStatusCheck, false, true);
+						SIPPYCUP.Options.RefreshStackSizes(SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.Database:GetGlobalSetting("MSPStatusCheck"), false, true);
 					end,
 				},
 				{
@@ -1707,18 +1698,18 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 					step = 1,
 					height = 35,
 					disabled = function()
-						return not SIPPYCUP.Database.GetGlobalSetting("ReflectingPrismPreExpirationLeadTimer");
+						return not SIPPYCUP.Database:GetGlobalSetting("ReflectingPrismPreExpirationLeadTimer");
 					end,
 					get = function()
-						return SIPPYCUP.Database.GetGlobalSetting("ReflectingPrismPreExpirationLeadTimer");
+						return SIPPYCUP.Database:GetGlobalSetting("ReflectingPrismPreExpirationLeadTimer");
 					end,
 					set = function(val)
-						SIPPYCUP.Database.SetGlobalSetting("ReflectingPrismPreExpirationLeadTimer", val);
+						SIPPYCUP.Database:SetGlobalSetting("ReflectingPrismPreExpirationLeadTimer", val);
 						local reason = SIPPYCUP.Popups.Reason.PRE_EXPIRATION;
 						SIPPYCUP.Auras.CancelAllPreExpirationTimers();
 						SIPPYCUP.Items.CancelAllItemTimers(reason);
 						SIPPYCUP.Popups.HideAllRefreshPopups(reason);
-						SIPPYCUP.Options.RefreshStackSizes(SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.global.MSPStatusCheck, false, true);
+						SIPPYCUP.Options.RefreshStackSizes(SIPPYCUP.MSP.IsEnabled() and SIPPYCUP.Database:GetGlobalSetting("MSPStatusCheck"), false, true);
 					end,
 				},
 			}
@@ -1767,10 +1758,10 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 						return IsToyDisabled(toyID);
 					end,
 					get = function()
-						return SIPPYCUP.Database.GetSetting(checkboxProfileKey).enable;
+						return SIPPYCUP.Database:GetAuraSetting(checkboxProfileKey, "enable");
 					end,
 					set = function(val)
-						SIPPYCUP.Database.SetSetting(checkboxProfileKey, { enable = val });
+						SIPPYCUP.Database:SetAuraSetting(checkboxProfileKey, "enable", val);
 						SIPPYCUP.Popups.Toggle(toyName, toyAura, val);
 					end,
 				};
@@ -1787,17 +1778,18 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 						max = optionData.maxStacks,
 						step = 1,
 						disabled = function()
-							return not SIPPYCUP.Database.GetSetting(sliderProfileKey).enable;
+							return not SIPPYCUP.Database:GetAuraSetting(sliderProfileKey, "enable");
 						end,
 						get = function()
-							return SIPPYCUP.Database.GetSetting(sliderProfileKey).desiredStacks;
+							return SIPPYCUP.Database:GetAuraSetting(sliderProfileKey, "desiredStacks");
 						end,
 						set = function(val)
-							SIPPYCUP.Database.SetSetting(sliderProfileKey, { desiredStacks = val });
-							if SIPPYCUP.Profile[sliderProfileKey].enable then
+							SIPPYCUP.Database:SetAuraSetting(sliderProfileKey, "desiredStacks", val);
+							local profileOptionData = SIPPYCUP.Database:GetProfileOption(sliderProfileKey);
+							if profileOptionData.enable then
 								SIPPYCUP.Popups.Toggle(toyName, toyAura, true);
 							end
-						end,
+						end
 					};
 				end
 			end
@@ -1823,7 +1815,7 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 		{
 			type = "description",
 			name = function()
-				return L.OPTIONS_PROFILES_CURRENTPROFILE:format("|cnNORMAL_FONT_COLOR:" .. SIPPYCUP.Database.GetCurrentProfileName() .. "|r");
+				return L.OPTIONS_PROFILES_CURRENTPROFILE:format("|cnNORMAL_FONT_COLOR:" .. SIPPYCUP.Database:GetProfileName() .. "|r");
 			end,
 		},
 		{
@@ -1834,13 +1826,13 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 			gearButton = true,
 			buildAdded = "0.7.5|120001",
 			values = function()
-				return SIPPYCUP.Database.GetAllProfiles();
+				return SIPPYCUP.Database:GetAllProfiles();
 			end,
 			get = function()
-				return SIPPYCUP.Database.GetCurrentProfileName();
+				return SIPPYCUP.Database:GetProfileName();
 			end,
 			set = function(val)
-				SIPPYCUP.Database.SetProfile(val);
+				SIPPYCUP.Database:SetProfile(val);
 			end,
 		},
 		{
@@ -1854,7 +1846,7 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 			get = function() end,
 			set = function(val)
 				SIPPYCUP.ConfirmDialog:Show(L.OPTIONS_PROFILES_NEWPROFILE_CONFIRM:format(val), function()
-					SIPPYCUP.Database.CreateProfile(val);
+					SIPPYCUP.Database:CreateProfile(val);
 				end);
 			end,
 		},
@@ -1864,12 +1856,12 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 			tooltip = L.OPTIONS_PROFILES_COPYFROM_DESC,
 			style = "button",
 			values = function()
-				return SIPPYCUP.Database.GetAllProfiles(true, false);
+				return SIPPYCUP.Database:GetAllProfiles(true, false);
 			end,
 			get = function() end,
 			set = function(val)
 				SIPPYCUP.ConfirmDialog:Show(L.OPTIONS_PROFILES_COPYFROM_CONFIRM:format(val), function()
-					SIPPYCUP.Database.CopyProfile(val);
+					SIPPYCUP.Database:CopyProfile(val);
 				end);
 			end,
 		},
@@ -1882,7 +1874,7 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 			tooltip = L.OPTIONS_PROFILES_RESETBUTTON_DESC,
 			func = function()
 				SIPPYCUP.ConfirmDialog:Show(L.OPTIONS_PROFILES_RESETBUTTON_CONFIRM, function()
-					SIPPYCUP.Database.ResetProfile();
+					SIPPYCUP.Database:ResetProfile();
 				end);
 			end,
 		},
@@ -1892,12 +1884,12 @@ function SIPPYCUP_ConfigMixin:OnLoad()
 			tooltip = L.OPTIONS_PROFILES_DELETEPROFILE_DESC,
 			style = "button",
 			values = function()
-				return SIPPYCUP.Database.GetAllProfiles(true, true);
+				return SIPPYCUP.Database:GetAllProfiles(true, true);
 			end,
 			get = function() end,
 			set = function(val)
 				SIPPYCUP.ConfirmDialog:Show(L.OPTIONS_PROFILES_DELETEPROFILE_CONFIRM:format(val), function()
-					SIPPYCUP.Database.DeleteProfile(val);
+					SIPPYCUP.Database:DeleteProfile(val);
 				end);
 			end,
 		},


### PR DESCRIPTION
Split SippyCupDB into both SippyCupDB and SippyCupCharDB.

(Chonky messages coming in, but it's mostly for my own memory and when something does break I know it happend here.)

We now properly save char-based info like currentInstanceID, currentStacks, currentItemID and lastItemCount instead of saving it on the profile itself. This means that every char using the same profile won't overwrite one another.

RebuildAuraMap now recalculates currentStacks and currentInstanceID from live aura data on login, fixing the bug where stale values persisted across sessions. ParseAura removal now zeros currentStacks immediately alongside currentInstanceID to prevent race conditions during debounce.

SetProfile, ResetProfile, and CopyProfile now properly clean up popups, cancel pre-expiration and item timers, and rebuild aura maps on profile change. SwitchProfileValues no longer calls data.set() on every widget, as RebuildAuraMap handles the state rebuild.

SetAuraSetting and SetCharSetting now prune empty sub-tables from saved variables. RebuildAuraMap prunes char data for options not enabled in the current profile.

profileKeys migrated from "Name - Realm Name" to "Name-RealmName" to match GetNormalizedRealmName.

Flyway patch 2: strip char-specific keys from profiles, migrate profileKeys to normalized realm format.